### PR TITLE
doc: update README.md with max python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ AIOS, a Large Language Model (LLM) Agent operating system, embeds large language
 ```bash
 git clone https://github.com/agiresearch/AIOS.git
 ```
-**Make sure you have Python >= 3.9**  
+**Make sure you have Python >= 3.9 and <= 3.11**  
 Install the required packages using pip  
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
Current requirements.txt has dependencies (at least in Ubuntu) that are not supported in Python 3.12.

```
Collecting Requests==2.31.0 (from -r requirements.txt (line 6))
  Downloading requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
ERROR: Ignored the following versions that require a different python version: 1.21.2 Requires-Python >=3.7,<3.11; 1.21.3 Requires-Python >=3.7,<3.11; 1.21.4 Requires-Python >=3.7,<3.11; 1.21.5 Requires-Python >=3.7,<3.11; 1.21.6 Requires-Python >=3.7,<3.11
ERROR: Could not find a version that satisfies the requirement torch==2.0.1 (from versions: 2.2.0, 2.2.1, 2.2.2)
ERROR: No matching distribution found for torch==2.0.1
```