### PR TITLE
[chore]: Adding CVE dependency checks for requirements.txt via pre-commit recommended hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,8 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+-   repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+    rev: v1.3.3
+    hooks:
+    -   id: python-safety-dependencies-check
+        args: ['--short-report']


### PR DESCRIPTION
Despite the [CVE bogus problem](https://news.ycombinator.com/item?id=37608110), I think that automatic dependency vulnerability scans is of the essence given the rapid pace of change that the field and its libraries experience. The hook added to the PR direclty checks against [safety-db](https://github.com/pyupio/safety-db) for known vulns. This hook is one of the supported hooks in the pre-commit documentation, present [here](https://pre-commit.com/hooks.html) and seems to me like the no brainer solution for implementing a one shot validation when requirements get updated.
 
For runs at the time of writing, the requirements established for AIOS show no existent vulnerability.

