### PR TITLE
feat: Add gpt-4o model to model registry

### DIFF
--- a/src/llm_kernel/llm_classes/model_registry.py
+++ b/src/llm_kernel/llm_classes/model_registry.py
@@ -8,5 +8,6 @@ MODEL_REGISTRY = {
     'bedrock/anthropic.claude-3-haiku-20240307-v1:0': BedrockLLM,
     'gemini-pro': GeminiLLM,
     'gpt-3.5-turbo': GPTLLM,
-    'gpt-4': GPTLLM
+    'gpt-4': GPTLLM,
+    'gpt-4o': GPTLLM
 }


### PR DESCRIPTION
## Description

This PR adds the `gpt-4o` model to the model registry in `model_registry.py`. The changes include:

- Added `gpt-4o` to the `MODEL_REGISTRY` dictionary, mapping it to `GPTLLM`.
