### PR TITLE
chore: add pyopenagi install from pypi and locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AIOS, a Large Language Model (LLM) Agent operating system, embeds large language
 <img src="images/AIOS-Architecture.png">
 </p>
 
-The objective of AIOS is to provide the LLM kernel which will be an abstraction on top of the OS kernel. The kernel intends to facilitate the installation of agents, which are utilities the kernel can interact with in order to perform tasks the user queries. For example, the MathAgent facilitates mathematical computations, such as currency conversion, integral calculus, or even basic algebraic manipulation. The method of installation is intended to be in a manner similar to [apt](https://en.wikipedia.org/wiki/APT_(software)) or [brew](https://brew.sh). 
+The objective of AIOS is to provide the LLM kernel which will be an abstraction on top of the OS kernel. The kernel intends to facilitate the installation of agents, which are utilities the kernel can interact with in order to perform tasks the user queries. For example, the MathAgent facilitates mathematical computations, such as currency conversion, integral calculus, or even basic algebraic manipulation. The method of installation is intended to be in a manner similar to [apt](https://en.wikipedia.org/wiki/APT_(software)) or [brew](https://brew.sh).
 
 At the present moment, AIOS is a userspace wrapper around the current kernel. However, this is subject to change as outlined in the [Q4 Goals and Objectives](https://github.com/agiresearch/AIOS/issues/127).
 
@@ -37,7 +37,7 @@ At the present moment, AIOS is a userspace wrapper around the current kernel. Ho
 - [git](https://git-scm.com/downloads)
 - [pip](https://pypi.org/project/pip/)
 
-At the minimum, we recommend a Nvidia GPU with 4 GB of memory or an ARM based Macbook. It should be able to run on machines with inferior hardware, but task completion time will increase greatly. If you notice a large delay in execution, you can try to use an API based model, such as gpt (paid) or gemini (free). 
+At the minimum, we recommend a Nvidia GPU with 4 GB of memory or an ARM based Macbook. It should be able to run on machines with inferior hardware, but task completion time will increase greatly. If you notice a large delay in execution, you can try to use an API based model, such as gpt (paid) or gemini (free).
 
 ### 3.2 Installation
 To run AIOS, you will need to install our agent creation package, [OpenAGI](https://github.com/agiresearch/OpenAGI).
@@ -62,16 +62,6 @@ python -m venv venv
 chmod +x venv/bin/activate
 . venv/bin/activate
 pip install -r requirements.txt
-```
-**Allow your code to be able to see 'openagi'**
-```bash
-cd ../OpenAGI
-pip install -e .
-```
-
-OpenAGI is **now on PyPi**, and can be installed easily with the following:
-```bash
-pip install pyopenagi
 ```
 
 ### 3.3 Usage
@@ -154,7 +144,7 @@ print agent
 A `run` command will **not output** to the standard output. Instead, it will create a log file.
 
 #### (3) Evaluation Mode
-In the evaluation mode, we draw prompts for each agent from `agent_configs/` and evaluate the performance of the agents by allowing the user to specify which agents should be run. 
+In the evaluation mode, we draw prompts for each agent from `agent_configs/` and evaluate the performance of the agents by allowing the user to specify which agents should be run.
 
 Additionally, you can evaluate the acceleration performance with or without AIOS by comparing the waiting time and turnaround time.
 

--- a/eval.py
+++ b/eval.py
@@ -1,4 +1,4 @@
-# This file is used to evaluate the configuration passed through arguments to the simulation of the kernel 
+# This file is used to evaluate the configuration passed through arguments to the simulation of the kernel
 
 import os
 import sys
@@ -8,9 +8,9 @@ from src.scheduler.fifo_scheduler import FIFOScheduler
 
 from src.scheduler.rr_scheduler import RRScheduler
 
-from openagi.src.agents.agent_factory import AgentFactory
+from pyopenagi.src.agents.agent_factory import AgentFactory
 
-from openagi.src.agents.agent_process import AgentProcessFactory
+from pyopenagi.src.agents.agent_process import AgentProcessFactory
 
 import warnings
 
@@ -22,7 +22,6 @@ from multiprocessing import Process
 
 from src.utils.utils import delete_directories
 from src.utils.calculator import get_numbers_concurrent, get_numbers_sequential, comparison
-from src.utils
 
 import argparse
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-# This is a main script that tests the functionality of specific agents. 
+# This is a main script that tests the functionality of specific agents.
 # It requires no user input.
 
 import os
@@ -13,9 +13,9 @@ from src.utils.utils import (
     parse_global_args,
 )
 
-from openagi.src.agents.agent_factory import AgentFactory
+from pyopenagi.src.agents.agent_factory import AgentFactory
 
-from openagi.src.agents.agent_process import AgentProcessFactory
+from pyopenagi.src.agents.agent_process import AgentProcessFactory
 
 import warnings
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ llama_index==0.10.39
 llama_index.embeddings.huggingface==0.2.0
 llama-index-vector-stores-chroma==0.1.8
 chromadb==0.5.0
+pyopenagi==0.0.3

--- a/simulator.py
+++ b/simulator.py
@@ -1,5 +1,5 @@
 # This simulates AIOS as an LLM kernel, although it is only acting as a userspace
-# wrapper in this script. 
+# wrapper in this script.
 
 import os
 import sys
@@ -22,9 +22,9 @@ from src.utils.utils import (
     parse_global_args,
 )
 
-from openagi.src.agents.agent_factory import AgentFactory
+from pyopenagi.src.agents.agent_factory import AgentFactory
 
-from openagi.src.agents.agent_process import AgentProcessFactory
+from pyopenagi.src.agents.agent_process import AgentProcessFactory
 
 import warnings
 


### PR DESCRIPTION
1. add pip install pyopenagi from both **pypi** and **locally**
    <img width="497" alt="Screenshot 2024-06-11 at 5 04 29 PM" src="https://github.com/agiresearch/AIOS/assets/48231234/4cc34393-df68-4dde-9b25-de3e2c0de3cd">
    <img width="746" alt="Screenshot 2024-06-11 at 5 09 19 PM" src="https://github.com/agiresearch/AIOS/assets/48231234/008687d8-4686-4abe-a070-b000139697ff">
2. add workflow for publish openagi package when using git tag and the tag name matches "v*", e.g., git tag v0.0.1, the publishment triggered by github action is shown as: 
    <img width="1094" alt="Screenshot 2024-06-11 at 5 10 37 PM" src="https://github.com/agiresearch/AIOS/assets/48231234/e8347742-a5cf-47c9-a855-9e9122d11cdb">
