### PR TITLE
v0.0.1.post1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,14 +2,14 @@ name: Publish Python Package
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
-  # push:
-  #   tags:
-  #     - 'v*'
+    types: [closed]
+    branches:
+      - main
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # if: ${{ github.event.pull_request.title ==~ /^v\d+\.\d+\.\d+$/ }}
+    if: github.event.pull_request.merged == true && github.event.pull_request.title ==~ /^v\d+\.\d+\.\d+(\.post\d+)?$/
 
     environment: release
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ license = {file = "LICENSE"}
 name = "pyaios"
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.0.1"
+version = "0.0.1.post1"
 
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 3 - Beta",
   "Intended Audience :: Developers",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
1. Attempt to release of a beta version of AIOS package
2. Update the github workflow to enable run `publish to PyPI` only when the PR meets the following two conditions
    - The PR title contains v*.\*.\*(e.g., v0.0.1) as the stable version (alpha version)or v*.\*.\*.post\* (e.g., v0.0.1.post1)as the development version (beta version)
    - The PR has been merged into the main branch