### PR TITLE
chore: update rules of publish to PyPI only after creating a github tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,13 @@
 name: Publish Python Package
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  # push:
-  #   tags:
-  #     - 'v*'
+  push:
+    tags:
+      - 'v*'
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # if: ${{ github.event.pull_request.title ==~ /^v\d+\.\d+\.\d+$/ }}
-
     environment: release
     permissions:
       id-token: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,14 @@ license = {file = "LICENSE"}
 name = "pyaios"
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.0.1"
+version = "0.0.1.beta1"
 
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "AIOS: LLM Agent Operating System"
 keywords = ["llm", "os"]
 license = {file = "LICENSE"}
 
-name = "aios_core"
+name = "aios-core"
 readme = "README.md"
 requires-python = ">=3.9"
 version = "0.0.1.beta2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@ description = "AIOS: LLM Agent Operating System"
 keywords = ["llm", "os"]
 license = {file = "LICENSE"}
 
-name = "pyaios"
+name = "aios_core"
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.0.1.beta1"
+version = "0.0.1.beta2"
 
 classifiers = [
   "Development Status :: 3 - Alpha",


### PR DESCRIPTION
1. Update rules of publish to PyPI only after creating a github tag. 
2. Upload a beta version to PyPI, where the package is currently named as [aios-core](https://pypi.org/project/aios-core/).