### PR TITLE
Fixed aios not working in ollama mode

### DIFF
--- a/aios/llm_kernel/llm_classes/ollama_llm.py
+++ b/aios/llm_kernel/llm_classes/ollama_llm.py
@@ -72,7 +72,9 @@ class OllamaLLM(BaseLLMKernel):
             response = ollama.chat(
                 model=self.model_name.split("/")[-1],
                 messages=messages,
-                num_predict=self.max_new_tokens
+                options= ollama.Options(
+                    num_predict=self.max_new_tokens
+                )
             )
             agent_process.set_response(
                 Response(

--- a/aios/llm_kernel/llms.py
+++ b/aios/llm_kernel/llms.py
@@ -27,7 +27,7 @@ class LLMKernel:
             )
         # For locally-deployed LLM
         else:
-            if use_backend == "ollama" and llm_name.startswith("ollama"):
+            if use_backend == "ollama" or llm_name.startswith("ollama"):
                 self.model = OllamaLLM(
                     llm_name=llm_name,
                     max_gpu_memory=max_gpu_memory,


### PR DESCRIPTION
There are currently two bugs that prevent the ollama mode from running properly

- llm_name judgment error, now all models are judged as vllm, including those with the ollama prefix
- The num_predict parameter is under ollama.Options

The running results after fix are as follows

```bash
(venv) (base) ➜  AIOS git:(main) python eval.py --llm_name ollama/qwen:7b --agents AcademicAgent:1
[🤖ollama/qwen:7b] AIOS LLM successfully loaded.

**** concurrent Execution Statistics Starts ****

[AcademicAgent] Initialized.

[AcademicAgent] The task you need to solve is: Summarize recent advancements in quantum computing from the past five years.


[Scheduler] AcademicAgent is executing.

[🤖ollama/qwen:7b] AcademicAgent is switched to executing.

[AcademicAgent] [[{"name": "arxiv", "arguments": {"query": "quantum computing recent advancements"}}}]]

[Scheduler] AcademicAgent is executing.

[🤖ollama/qwen:7b] AcademicAgent is switched to executing.

[AcademicAgent] At current step, I will utilize the tool 'arxiv' to gather information on recent advancements in quantum computing.

JSON call:
{["arxiv", {"query": "quantum computing recent advancements"}]]}

The output will be a list of relevant articles from arxiv, focusing on the latest developments in quantum computing.

Concurrent Metrics: {'agent_waiting_time': {'avg': 0.00016880035400390625, 'p90': 0.00016880035400390625, 'p99': 0.00016880035400390625}, 'agent_turnaround_time': {'avg': 6.717123031616211, 'p90': 6.717123031616211, 'p99': 6.717123031616211}, 'request_waiting_time': {'avg': 0.00021958351135253906, 'p90': 0.0003088474273681641, 'p99': 0.0003289318084716797}, 'request_turnaround_time': {'avg': 3.2654584646224976, 'p90': 3.6847620725631716, 'p99': 3.779105384349823}}
**** concurrent Execution Statistics Ends ****

**** sequential Execution Statistics Starts ****

[AcademicAgent] Initialized.

[AcademicAgent] The task you need to solve is: Summarize recent advancements in quantum computing from the past five years.


[Scheduler] AcademicAgent is executing.

[🤖ollama/qwen:7b] AcademicAgent is switched to executing.

```