### PR TITLE
fix memory_clear bug

### DIFF
--- a/aios/memory/single_memory.py
+++ b/aios/memory/single_memory.py
@@ -103,5 +103,6 @@ class UniformedMemoryManager(BaseMemoryManager):
         }
 
     def mem_clear(self, agent_id):
-        self.aid_to_mid.pop(agent_id)
-        heapq.heappush(agent_id)
+        memory_block = self.aid_to_memory.pop(agent_id)
+        memory_block_id = memory_block['memory_block_id']
+        heapq.heappush(self.free_memory_blocks, memory_block_id)


### PR DESCRIPTION
```py
    def mem_clear(self, agent_id):
        self.aid_to_mid.pop(agent_id)
        heapq.heappush(agent_id)
```
I search `aid_to_mid`function in AIOS, but there is no such a function. 
and `heapq.heappush` should have two arguments, and the id should be memory_block_id
Based on the mem_alloc function， mem_clear should be
```py
def mem_clear(self, agent_id):
    memory_block = self.aid_to_memory.pop(agent_id)
    memory_block_id = memory_block['memory_block_id']
    heapq.heappush(self.free_memory_blocks, memory_block_id)
```