### PR TITLE
feat: autogen adapter

### DIFF
--- a/aios/llm_core/llm_classes/gpt_llm.py
+++ b/aios/llm_core/llm_classes/gpt_llm.py
@@ -36,7 +36,9 @@ class GPTLLM(BaseLLM):
                 parsed_tool_calls.append(
                     {
                         "name": function_name,
-                        "parameters": function_args
+                        "parameters": function_args,
+                        "type": tool_call.type,
+                        "id": tool_call.id
                     }
                 )
             return parsed_tool_calls

--- a/aios/sdk/autogen/adapater.py
+++ b/aios/sdk/autogen/adapater.py
@@ -1,0 +1,36 @@
+from aios.sdk.autogen.agent_adapter import (
+    adapter_autogen_agent_init,
+    _adapter_print_received_message,
+    _adapter_generate_oai_reply_from_client,
+    adapter_generate_tool_calls_reply,
+    adapter_execute_function,
+    adapter_update_tool_signature
+)
+from aios.utils.logger import BaseLogger
+
+try:
+    from autogen import (
+        OpenAIWrapper,
+        ConversableAgent
+    )
+except ImportError:
+    raise ImportError(
+        "Could not import autogen python package. "
+        "Please install it with `pip install pyautogen`."
+    )
+
+logger = BaseLogger("Adapter")
+
+
+def prepare_autogen():
+    """adapter autogen for aios
+    """
+    # Replace agent method
+    ConversableAgent.__init__ = adapter_autogen_agent_init
+    ConversableAgent._print_received_message = _adapter_print_received_message
+    ConversableAgent._generate_oai_reply_from_client = _adapter_generate_oai_reply_from_client
+    ConversableAgent.generate_tool_calls_reply = adapter_generate_tool_calls_reply
+    ConversableAgent.execute_function = adapter_execute_function
+    ConversableAgent.update_tool_signature = adapter_update_tool_signature
+
+    logger.log("Autogen prepare success", "info")

--- a/aios/sdk/autogen/adapater.py
+++ b/aios/sdk/autogen/adapater.py
@@ -1,3 +1,5 @@
+from pyopenagi.agents.agent_process import AgentProcessFactory
+
 from aios.sdk.autogen.agent_adapter import (
     adapter_autogen_agent_init,
     _adapter_print_received_message,
@@ -6,7 +8,14 @@ from aios.sdk.autogen.agent_adapter import (
     adapter_execute_function,
     adapter_update_tool_signature
 )
-from aios.utils.logger import BaseLogger
+
+from aios.sdk.autogen.client_adapter import (
+    adapter_autogen_client_init,
+    adapter_client_create,
+    adapter_client_extract_text_or_completion_object
+)
+
+from aios.utils.logger import AgentLogger
 
 try:
     from autogen import (
@@ -19,18 +28,24 @@ except ImportError:
         "Please install it with `pip install pyautogen`."
     )
 
-logger = BaseLogger("Adapter")
+logger = AgentLogger("Adapter")
 
 
-def prepare_autogen():
+def prepare_autogen(agent_process_factory: AgentProcessFactory):
     """adapter autogen for aios
     """
+    # Replace OpenAIWrapper method
+    OpenAIWrapper.__init__ = adapter_autogen_client_init
+    OpenAIWrapper.create = adapter_client_create
+    OpenAIWrapper.extract_text_or_completion_object = adapter_client_extract_text_or_completion_object
+
     # Replace agent method
-    ConversableAgent.__init__ = adapter_autogen_agent_init
+    ConversableAgent.agent_process_factory = agent_process_factory
     ConversableAgent._print_received_message = _adapter_print_received_message
     ConversableAgent._generate_oai_reply_from_client = _adapter_generate_oai_reply_from_client
     ConversableAgent.generate_tool_calls_reply = adapter_generate_tool_calls_reply
     ConversableAgent.execute_function = adapter_execute_function
     ConversableAgent.update_tool_signature = adapter_update_tool_signature
+    ConversableAgent.__init__ = adapter_autogen_agent_init
 
     logger.log("Autogen prepare success", "info")

--- a/aios/sdk/autogen/adapater.py
+++ b/aios/sdk/autogen/adapater.py
@@ -1,4 +1,5 @@
 from pyopenagi.agents.agent_process import AgentProcessFactory
+from typing import Optional
 
 from aios.sdk.autogen.agent_adapter import (
     adapter_autogen_agent_init,
@@ -31,7 +32,7 @@ except ImportError:
 logger = AgentLogger("Adapter")
 
 
-def prepare_autogen(agent_process_factory: AgentProcessFactory):
+def prepare_autogen(agent_process_factory: Optional[AgentProcessFactory] = None):
     """adapter autogen for aios
     """
     # Replace OpenAIWrapper method

--- a/aios/sdk/autogen/adapater.py
+++ b/aios/sdk/autogen/adapater.py
@@ -7,6 +7,7 @@ from aios.sdk.autogen.agent_adapter import (
     _adapter_generate_oai_reply_from_client,
     adapter_generate_tool_calls_reply,
     adapter_execute_function,
+    _adapter_a_execute_tool_call,
     adapter_update_tool_signature
 )
 
@@ -46,6 +47,7 @@ def prepare_autogen(agent_process_factory: Optional[AgentProcessFactory] = None)
     ConversableAgent._generate_oai_reply_from_client = _adapter_generate_oai_reply_from_client
     ConversableAgent.generate_tool_calls_reply = adapter_generate_tool_calls_reply
     ConversableAgent.execute_function = adapter_execute_function
+    ConversableAgent._a_execute_tool_call = _adapter_a_execute_tool_call
     ConversableAgent.update_tool_signature = adapter_update_tool_signature
     ConversableAgent.__init__ = adapter_autogen_agent_init
 

--- a/aios/sdk/autogen/agent_adapter.py
+++ b/aios/sdk/autogen/agent_adapter.py
@@ -265,7 +265,6 @@ def _adapter_generate_oai_reply_from_client(self, llm_client, messages, cache) -
         context=messages[-1].pop("context", None), messages=all_messages, cache=cache, agent=self
     )
     extracted_response = llm_client.extract_text_or_completion_object(response)[0]
-
     if extracted_response is None:
         warnings.warn(f"Extracted_response from {response} is None.", UserWarning)
         return None

--- a/aios/sdk/autogen/agent_adapter.py
+++ b/aios/sdk/autogen/agent_adapter.py
@@ -391,6 +391,15 @@ def adapter_execute_function(self, func_call, verbose: bool = False) -> Tuple[bo
         "content": str(content),
     }
 
+async def _adapter_a_execute_tool_call(self, tool_call):
+    id = tool_call["id"]
+    function_call = tool_call
+    _, func_return = await self.a_execute_function(function_call)
+    return {
+        "tool_call_id": id,
+        "role": "tool",
+        "content": func_return.get("content", ""),
+    }
 
 def adapter_update_tool_signature(self, tool_sig: Union[str, Dict], is_remove: None):
     """update a tool_signature in the LLM configuration for tool_call.

--- a/aios/sdk/autogen/agent_adapter.py
+++ b/aios/sdk/autogen/agent_adapter.py
@@ -64,7 +64,7 @@ def adapter_autogen_agent_init(
     self.agent_name = name
 
     # just save tool/function message in aios
-    self.llm_config = {}
+    self.llm_config = {} if llm_config is not False else False
     self.client = None if (self.llm_config is False or not self.agent_process_factory) else OpenAIWrapper(
         **self.llm_config,
         agent_process_factory=self.agent_process_factory,

--- a/aios/sdk/autogen/agent_adapter.py
+++ b/aios/sdk/autogen/agent_adapter.py
@@ -1,0 +1,443 @@
+import asyncio
+import copy
+import inspect
+import warnings
+from collections import defaultdict
+from typing import (
+    Optional,
+    Callable,
+    Union,
+    List,
+    Dict,
+    Literal, Any, Tuple
+)
+
+from autogen._pydantic import model_dump
+from autogen.coding import CodeExecutorFactory
+from autogen.io import IOStream
+
+from aios.sdk.autogen.client_adapter import AutogenClientAdapter
+from pyopenagi.agents.agent_process import AgentProcessFactory
+from termcolor import colored
+
+try:
+    from autogen import (
+        OpenAIWrapper,
+        ConversableAgent,
+        Agent
+    )
+    from autogen.code_utils import (
+        content_str,
+        decide_use_docker,
+        check_can_use_docker_or_throw
+    )
+    from autogen.runtime_logging import (
+        logging_enabled,
+        log_new_agent
+    )
+except ImportError:
+    raise ImportError(
+        "Could not import autogen python package. "
+        "Please install it with `pip install pyautogen`."
+    )
+
+
+def adapter_autogen_agent_init(
+    self,
+    name: str,
+    system_message: Optional[Union[str, List]] = "You are a helpful AI Assistant.",
+    is_termination_msg: Optional[Callable[[Dict], bool]] = None,
+    max_consecutive_auto_reply: Optional[int] = None,
+    human_input_mode: Literal["ALWAYS", "NEVER", "TERMINATE"] = "TERMINATE",
+    function_map: Optional[Dict[str, Callable]] = None,
+    code_execution_config: Union[Dict, Literal[False]] = False,
+    llm_config: Optional[Union[Dict, Literal[False]]] = None,
+    default_auto_reply: Union[str, Dict] = "",
+    description: Optional[str] = None,
+    chat_messages: Optional[Dict[Agent, List[Dict]]] = None,
+    silent: Optional[bool] = None,
+    agent_process_factory: Optional[AgentProcessFactory] = None,
+):
+    if agent_process_factory:
+        self.agent_process_factory = agent_process_factory
+    self.agent_name = name
+
+    # just save tool/function message in aios
+    self.llm_config = {}
+    self.client = None if (self.llm_config is False or not agent_process_factory) else AutogenClientAdapter(
+        **self.llm_config,
+        agent_process_factory=self.agent_process_factory,
+        agent_name=self.agent_name
+    )
+
+    # we change code_execution_config below and we have to make sure we don't change the input
+    # in case of UserProxyAgent, without this we could even change the default value {}
+    code_execution_config = (
+        code_execution_config.copy() if hasattr(code_execution_config, "copy") else code_execution_config
+    )
+
+    self._name = name
+    # a dictionary of conversations, default value is list
+    if chat_messages is None:
+        self._oai_messages = defaultdict(list)
+    else:
+        self._oai_messages = chat_messages
+
+    self._oai_system_message = [{"content": system_message, "role": "system"}]
+    self._description = description if description is not None else system_message
+    self._is_termination_msg = (
+        is_termination_msg
+        if is_termination_msg is not None
+        else (lambda x: content_str(x.get("content")) == "TERMINATE")
+    )
+    self.silent = silent
+    # Take a copy to avoid modifying the given dict
+    if isinstance(llm_config, dict):
+        try:
+            llm_config = copy.deepcopy(llm_config)
+        except TypeError as e:
+            raise TypeError(
+                "Please implement __deepcopy__ method for each value class in llm_config to support deepcopy."
+                " Refer to the docs for more details: https://microsoft.github.io/autogen/docs/topics/llm_configuration#adding-http-client-in-llm_config-for-proxy"
+            ) from e
+
+    self._validate_llm_config(llm_config)
+
+    if logging_enabled():
+        log_new_agent(self, locals())
+
+    # Initialize standalone client cache object.
+    self.client_cache = None
+
+    self.human_input_mode = human_input_mode
+    self._max_consecutive_auto_reply = (
+        max_consecutive_auto_reply if max_consecutive_auto_reply is not None else self.MAX_CONSECUTIVE_AUTO_REPLY
+    )
+    self._consecutive_auto_reply_counter = defaultdict(int)
+    self._max_consecutive_auto_reply_dict = defaultdict(self.max_consecutive_auto_reply)
+    self._function_map = (
+        {}
+        if function_map is None
+        else {name: callable for name, callable in function_map.items() if self._assert_valid_name(name)}
+    )
+    self._default_auto_reply = default_auto_reply
+    self._reply_func_list = []
+    self._human_input = []
+    self.reply_at_receive = defaultdict(bool)
+    self.register_reply([Agent, None], ConversableAgent.generate_oai_reply)
+    self.register_reply([Agent, None], ConversableAgent.a_generate_oai_reply, ignore_async_in_sync_chat=True)
+
+    # Setting up code execution.
+    # Do not register code execution reply if code execution is disabled.
+    if code_execution_config is not False:
+        # If code_execution_config is None, set it to an empty dict.
+        if code_execution_config is None:
+            warnings.warn(
+                "Using None to signal a default code_execution_config is deprecated. "
+                "Use {} to use default or False to disable code execution.",
+                stacklevel=2,
+            )
+            code_execution_config = {}
+        if not isinstance(code_execution_config, dict):
+            raise ValueError("code_execution_config must be a dict or False.")
+
+        # We have got a valid code_execution_config.
+        self._code_execution_config = code_execution_config
+
+        if self._code_execution_config.get("executor") is not None:
+            if "use_docker" in self._code_execution_config:
+                raise ValueError(
+                    "'use_docker' in code_execution_config is not valid when 'executor' is set. Use the appropriate arg in the chosen executor instead."
+                )
+
+            if "work_dir" in self._code_execution_config:
+                raise ValueError(
+                    "'work_dir' in code_execution_config is not valid when 'executor' is set. Use the appropriate arg in the chosen executor instead."
+                )
+
+            if "timeout" in self._code_execution_config:
+                raise ValueError(
+                    "'timeout' in code_execution_config is not valid when 'executor' is set. Use the appropriate arg in the chosen executor instead."
+                )
+
+            # Use the new code executor.
+            self._code_executor = CodeExecutorFactory.create(self._code_execution_config)
+            self.register_reply([Agent, None], ConversableAgent._generate_code_execution_reply_using_executor)
+        else:
+            # Legacy code execution using code_utils.
+            use_docker = self._code_execution_config.get("use_docker", None)
+            use_docker = decide_use_docker(use_docker)
+            check_can_use_docker_or_throw(use_docker)
+            self._code_execution_config["use_docker"] = use_docker
+            self.register_reply([Agent, None], ConversableAgent.generate_code_execution_reply)
+    else:
+        # Code execution is disabled.
+        self._code_execution_config = False
+
+    self.register_reply([Agent, None], ConversableAgent.generate_tool_calls_reply)
+    self.register_reply([Agent, None], ConversableAgent.a_generate_tool_calls_reply, ignore_async_in_sync_chat=True)
+    self.register_reply([Agent, None], ConversableAgent.generate_function_call_reply)
+    self.register_reply(
+        [Agent, None], ConversableAgent.a_generate_function_call_reply, ignore_async_in_sync_chat=True
+    )
+    self.register_reply([Agent, None], ConversableAgent.check_termination_and_human_reply)
+    self.register_reply(
+        [Agent, None], ConversableAgent.a_check_termination_and_human_reply, ignore_async_in_sync_chat=True
+    )
+
+    # Registered hooks are kept in lists, indexed by hookable method, to be called in their order of registration.
+    # New hookable methods should be added to this list as required to support new agent capabilities.
+    self.hook_lists: Dict[str, List[Callable]] = {
+        "process_last_received_message": [],
+        "process_all_messages_before_reply": [],
+        "process_message_before_send": [],
+    }
+
+
+def _adapter_print_received_message(self, message: Union[Dict, str], sender: Agent):
+    iostream = IOStream.get_default()
+    # print the message received
+    iostream.print(colored(sender.name, "yellow"), "(to", f"{self.name}):\n", flush=True)
+    message = self._message_to_dict(message)
+
+    if message.get("tool_responses"):  # Handle tool multi-call responses
+        for tool_response in message["tool_responses"]:
+            self._print_received_message(tool_response, sender)
+        if message.get("role") == "tool":
+            return  # If role is tool, then content is just a concatenation of all tool_responses
+
+    if message.get("role") in ["function", "tool"]:
+        if message["role"] == "function":
+            id_key = "name"
+        else:
+            id_key = "tool_call_id"
+        id = message.get(id_key, "No id found")
+        func_print = f"***** Response from calling {message['role']} ({id}) *****"
+        iostream.print(colored(func_print, "green"), flush=True)
+        iostream.print(message["content"], flush=True)
+        iostream.print(colored("*" * len(func_print), "green"), flush=True)
+    else:
+        content = message.get("content")
+        if content is not None:
+            if "context" in message:
+                content = OpenAIWrapper.instantiate(
+                    content,
+                    message["context"],
+                    self.llm_config and self.llm_config.get("allow_format_str_template", False),
+                )
+            iostream.print(content_str(content), flush=True)
+        if "function_call" in message and message["function_call"]:
+            function_call = dict(message["function_call"])
+            func_print = (
+                f"***** Suggested function call: {function_call.get('name', '(No function name found)')} *****"
+            )
+            iostream.print(colored(func_print, "green"), flush=True)
+            iostream.print(
+                "Arguments: \n",
+                function_call.get("arguments", "(No arguments found)"),
+                flush=True,
+                sep="",
+            )
+            iostream.print(colored("*" * len(func_print), "green"), flush=True)
+        if "tool_calls" in message and message["tool_calls"]:
+            for tool_call in message["tool_calls"]:
+                id = tool_call.get("id", "No tool call id found")
+                # function_call = dict(tool_call.get("function", {}))
+                function_call = tool_call
+                func_print = f"***** Suggested tool call ({id}): {function_call.get('name', '(No function name found)')} *****"
+                iostream.print(colored(func_print, "green"), flush=True)
+                iostream.print(
+                    "Parameters: \n",
+                    function_call.get("parameters", "(No parameters found)"),
+                    flush=True,
+                    sep="",
+                )
+                iostream.print(colored("*" * len(func_print), "green"), flush=True)
+
+    iostream.print("\n", "-" * 80, flush=True, sep="")
+
+
+def _adapter_generate_oai_reply_from_client(self, llm_client, messages, cache) -> Union[str, Dict, None]:
+    # unroll tool_responses
+    all_messages = []
+    for message in messages:
+        tool_responses = message.get("tool_responses", [])
+        if tool_responses:
+            all_messages += tool_responses
+            # tool role on the parent message means the content is just concatenation of all of the tool_responses
+            if message.get("role") != "tool":
+                all_messages.append({key: message[key] for key in message if key != "tool_responses"})
+        else:
+            all_messages.append(message)
+
+    # TODO: #1143 handle token limit exceeded error
+    response = llm_client.create(
+        context=messages[-1].pop("context", None), messages=all_messages, cache=cache, agent=self
+    )
+    extracted_response = llm_client.extract_text_or_completion_object(response)[0]
+
+    if extracted_response is None:
+        warnings.warn(f"Extracted_response from {response} is None.", UserWarning)
+        return None
+    # ensure function and tool calls will be accepted when sent back to the LLM
+    if not isinstance(extracted_response, str) and hasattr(extracted_response, "model_dump"):
+        extracted_response = model_dump(extracted_response)
+    if isinstance(extracted_response, dict):
+        if extracted_response.get("function_call"):
+            extracted_response["function_call"]["name"] = self._normalize_name(
+                extracted_response["function_call"]["name"]
+            )
+        for tool_call in extracted_response.get("tool_calls") or []:
+            tool_call["name"] = self._normalize_name(tool_call["name"])
+            tool_call["function"] = {"name": tool_call["name"], "arguments": str(tool_call["parameters"])}
+    return extracted_response
+
+
+def adapter_generate_tool_calls_reply(
+        self,
+        messages: Optional[List[Dict]] = None,
+        sender: Optional[Agent] = None,
+        config: Optional[Any] = None,
+) -> Tuple[bool, Union[Dict, None]]:
+    """Generate a reply using tool call."""
+    if config is None:
+        config = self
+    if messages is None:
+        messages = self._oai_messages[sender]
+    message = messages[-1]
+    tool_returns = []
+    for tool_call in message.get("tool_calls", []):
+        function_call = tool_call
+        func = self._function_map.get(function_call.get("name", None), None)
+        if inspect.iscoroutinefunction(func):
+            try:
+                # get the running loop if it was already created
+                loop = asyncio.get_running_loop()
+                close_loop = False
+            except RuntimeError:
+                # create a loop if there is no running loop
+                loop = asyncio.new_event_loop()
+                close_loop = True
+
+            _, func_return = loop.run_until_complete(self.a_execute_function(function_call))
+            if close_loop:
+                loop.close()
+        else:
+            _, func_return = self.execute_function(function_call)
+        content = func_return.get("content", "")
+        if content is None:
+            content = ""
+        tool_call_id = tool_call.get("id", None)
+        if tool_call_id is not None:
+            tool_call_response = {
+                "tool_call_id": tool_call_id,
+                "role": "tool",
+                "content": content,
+            }
+        else:
+            # Do not include tool_call_id if it is not present.
+            # This is to make the tool call object compatible with Mistral API.
+            tool_call_response = {
+                "role": "tool",
+                "content": content,
+            }
+        tool_returns.append(tool_call_response)
+    if tool_returns:
+        return True, {
+            "role": "tool",
+            "tool_responses": tool_returns,
+            "content": "\n\n".join([self._str_for_tool_response(tool_return) for tool_return in tool_returns]),
+        }
+    return False, None
+
+
+def adapter_execute_function(self, func_call, verbose: bool = False) -> Tuple[bool, Dict[str, str]]:
+    """Execute a function call and return the result.
+
+    Override this function to modify the way to execute function and tool calls.
+
+    Args:
+        func_call: a dictionary extracted from openai message at "function_call" or "tool_calls" with keys "name" and "arguments".
+
+    Returns:
+        A tuple of (is_exec_success, result_dict).
+        is_exec_success (boolean): whether the execution is successful.
+        result_dict: a dictionary with keys "name", "role", and "content". Value of "role" is "function".
+
+    "function_call" deprecated as of [OpenAI API v1.1.0](https://github.com/openai/openai-python/releases/tag/v1.1.0)
+    See https://platform.openai.com/docs/api-reference/chat/create#chat-create-function_call
+    """
+    iostream = IOStream.get_default()
+
+    func_name = func_call.get("name", "")
+    func = self._function_map.get(func_name, None)
+
+    is_exec_success = False
+    if func is not None:
+        arguments = func_call.get("parameters", None)
+
+        # Try to execute the function
+        if arguments is not None:
+            iostream.print(
+                colored(f"\n>>>>>>>> EXECUTING FUNCTION {func_name}...", "magenta"),
+                flush=True,
+            )
+            try:
+                content = func(**arguments)
+                is_exec_success = True
+            except Exception as e:
+                content = f"Error: {e}"
+    else:
+        content = f"Error: Function {func_name} not found."
+
+    if verbose:
+        iostream.print(
+            colored(f"\nInput arguments: {arguments}\nOutput:\n{content}", "magenta"),
+            flush=True,
+        )
+
+    return is_exec_success, {
+        "name": func_name,
+        "role": "function",
+        "content": str(content),
+    }
+
+
+def adapter_update_tool_signature(self, tool_sig: Union[str, Dict], is_remove: None):
+    """update a tool_signature in the LLM configuration for tool_call.
+
+    Args:
+        tool_sig (str or dict): description/name of the tool to update/remove to the model. See: https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools
+        is_remove: whether removing the tool from llm_config with name 'tool_sig'
+    """
+
+    if is_remove:
+        if "tools" not in self.llm_config.keys():
+            error_msg = "The agent config doesn't have tool {name}.".format(name=tool_sig)
+            logger.error(error_msg)
+            raise AssertionError(error_msg)
+        else:
+            self.llm_config["tools"] = [
+                tool for tool in self.llm_config["tools"] if tool["function"]["name"] != tool_sig
+            ]
+    else:
+        if not isinstance(tool_sig, dict):
+            raise ValueError(
+                f"The tool signature must be of the type dict. Received tool signature type {type(tool_sig)}"
+            )
+        self._assert_valid_name(tool_sig["function"]["name"])
+        if "tools" in self.llm_config:
+            if any(tool["function"]["name"] == tool_sig["function"]["name"] for tool in self.llm_config["tools"]):
+                warnings.warn(f"Function '{tool_sig['function']['name']}' is being overridden.", UserWarning)
+            self.llm_config["tools"] = [
+                                           tool
+                                           for tool in self.llm_config["tools"]
+                                           if tool.get("function", {}).get("name") != tool_sig["function"]["name"]
+                                       ] + [tool_sig]
+        else:
+            self.llm_config["tools"] = [tool_sig]
+
+    if len(self.llm_config["tools"]) == 0:
+        del self.llm_config["tools"]
+
+    self.client = OpenAIWrapper(**self.llm_config)

--- a/aios/sdk/autogen/client_adapter.py
+++ b/aios/sdk/autogen/client_adapter.py
@@ -1,0 +1,226 @@
+import uuid
+import logging
+from logging import ERROR
+
+from typing import (
+    Optional,
+    List,
+    Dict,
+    Any, Union
+)
+
+from autogen.logger.logger_utils import get_current_ts
+from autogen.oai.client import LEGACY_DEFAULT_CACHE_SEED, LEGACY_CACHE_DIR, PlaceHolderClient
+from autogen.oai.openai_utils import get_key
+from autogen.runtime_logging import logging_enabled, log_new_wrapper, log_chat_completion
+from openai import APITimeoutError, APIError
+from pyopenagi.agents.agent_process import AgentProcessFactory
+
+from pyopenagi.utils.chat_template import Query
+from pyopenagi.agents.call_core import CallCore
+
+try:
+    from autogen import (
+        OpenAIWrapper, ModelClient, Cache
+    )
+except ImportError:
+    raise ImportError(
+        "Could not import autogen python package. "
+        "Please install it with `pip install pyautogen`."
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class AutogenClientAdapter(OpenAIWrapper, CallCore):
+    def __int__(self, *,
+                config_list: Optional[List[Dict[str, Any]]] = None,
+                agent_process_factory: Optional[AgentProcessFactory] = None,
+                agent_name: Optional[str],
+                **base_config: Any):
+        if agent_name and agent_process_factory:
+            CallCore.__init__(self, agent_name, agent_process_factory, "console")
+
+        if logging_enabled():
+            log_new_wrapper(self, locals())
+        openai_config, extra_kwargs = self._separate_openai_config(base_config)
+        # It's OK if "model" is not provided in base_config or config_list
+        # Because one can provide "model" at `create` time.
+
+        self._clients: List[ModelClient] = []
+        self._config_list: List[Dict[str, Any]] = []
+
+        self._config_list = [extra_kwargs]
+        self.wrapper_id = id(self)
+
+    def create(self, **config: Any) -> ModelClient.ModelClientResponseProtocol:
+        if ERROR:
+            raise ERROR
+        invocation_id = str(uuid.uuid4())
+        last = len(self._clients) - 1
+        # Check if all configs in config list are activated
+        non_activated = [
+            client.config["model_client_cls"] for client in self._clients if isinstance(client, PlaceHolderClient)
+        ]
+        if non_activated:
+            raise RuntimeError(
+                f"Model client(s) {non_activated} are not activated. Please register the custom model clients using `register_model_client` or filter them out form the config list."
+            )
+        for i, client in enumerate([None]):
+            # merge the input config with the i-th config in the config list
+            full_config = {**config, **self._config_list[i]}
+            # separate the config into create_config and extra_kwargs
+            create_config, extra_kwargs = self._separate_create_config(full_config)
+            api_type = extra_kwargs.get("api_type")
+            if api_type and api_type.startswith("azure") and "model" in create_config:
+                create_config["model"] = create_config["model"].replace(".", "")
+            # construct the create params
+            params = self._construct_create_params(create_config, extra_kwargs)
+            # get the cache_seed, filter_func and context
+            cache_seed = extra_kwargs.get("cache_seed", LEGACY_DEFAULT_CACHE_SEED)
+            cache = extra_kwargs.get("cache")
+            filter_func = extra_kwargs.get("filter_func")
+            context = extra_kwargs.get("context")
+            agent = extra_kwargs.get("agent")
+            price = extra_kwargs.get("price", None)
+            if isinstance(price, list):
+                price = tuple(price)
+            elif isinstance(price, float) or isinstance(price, int):
+                logger.warning(
+                    "Input price is a float/int. Using the same price for prompt and completion tokens. Use a list/tuple if prompt and completion token prices are different."
+                )
+
+            cache_client = None
+            if cache is not None:
+                # Use the cache object if provided.
+                cache_client = cache
+            elif cache_seed is not None:
+                # Legacy cache behavior, if cache_seed is given, use DiskCache.
+                cache_client = Cache.disk(cache_seed, LEGACY_CACHE_DIR)
+
+            if cache_client is not None:
+                with cache_client as cache:
+                    # Try to get the response from cache
+                    key = get_key(params)
+                    request_ts = get_current_ts()
+
+                    response: ModelClient.ModelClientResponseProtocol = cache.get(key, None)
+
+                    if response is not None:
+                        # response.message_retrieval_function = client.message_retrieval
+                        # try:
+                        #     response.cost  # type: ignore [attr-defined]
+                        # except AttributeError:
+                        #     # update attribute if cost is not calculated
+                        #     response.cost = client.cost(response)
+                        #     cache.set(key, response)
+                        # total_usage = client.get_usage(response)
+
+                        if logging_enabled():
+                            # Log the cache hit
+                            # TODO: log the config_id and pass_filter etc.
+                            log_chat_completion(
+                                invocation_id=invocation_id,
+                                client_id=id(client),
+                                wrapper_id=id(self),
+                                agent=agent,
+                                request=params,
+                                response=response,
+                                is_cached=1,
+                                cost=response.cost,
+                                start_time=request_ts,
+                            )
+
+                        # check the filter
+                        pass_filter = filter_func is None or filter_func(context=context, response=response)
+                        if pass_filter or i == last:
+                            # Return the response if it passes the filter or it is the last client
+                            # response.config_id = i
+                            # response.pass_filter = pass_filter
+                            # self._update_usage(actual_usage=actual_usage, total_usage=total_usage)
+                            return response
+                        continue  # filter is not passed; try the next config
+            try:
+                request_ts = get_current_ts()
+                response, start_times, end_times, waiting_times, turnaround_times = self.get_response(
+                    query=Query(
+                        messages=params['messages'],
+                        tools=(params["tools"] if "tools" in params else None)
+                    )
+                )
+                response = {'content': response.response_message, 'tool_calls': response.tool_calls}
+            except APITimeoutError as err:
+                logger.debug(f"config {i} timed out", exc_info=True)
+                if i == last:
+                    raise TimeoutError(
+                        "OpenAI API call timed out. This could be due to congestion or too small a timeout value. The timeout can be specified by setting the 'timeout' value (in seconds) in the llm_config (if you are using agents) or the OpenAIWrapper constructor (if you are using the OpenAIWrapper directly)."
+                    ) from err
+            except APIError as err:
+                error_code = getattr(err, "code", None)
+                if logging_enabled():
+                    log_chat_completion(
+                        invocation_id=invocation_id,
+                        client_id=id(client),
+                        wrapper_id=id(self),
+                        agent=agent,
+                        request=params,
+                        response=f"error_code:{error_code}, config {i} failed",
+                        is_cached=0,
+                        cost=0,
+                        start_time=request_ts,
+                    )
+
+                if error_code == "content_filter":
+                    # raise the error for content_filter
+                    raise
+                logger.debug(f"config {i} failed", exc_info=True)
+                if i == last:
+                    raise
+            else:
+                # # add cost calculation before caching no matter filter is passed or not
+                # if price is not None:
+                #     response.cost = self._cost_with_customized_price(response, price)
+                # else:
+                #     response.cost = client.cost(response)
+                # actual_usage = client.get_usage(response)
+                # total_usage = actual_usage.copy() if actual_usage is not None else total_usage
+                # self._update_usage(actual_usage=actual_usage, total_usage=total_usage)
+                if cache_client is not None:
+                    # Cache the response
+                    with cache_client as cache:
+                        cache.set(key, response)
+
+                if logging_enabled():
+                    # TODO: log the config_id and pass_filter etc.
+                    log_chat_completion(
+                        invocation_id=invocation_id,
+                        client_id=id(client),
+                        wrapper_id=id(self),
+                        agent=agent,
+                        request=params,
+                        response=response,
+                        is_cached=0,
+                        cost=response.cost,
+                        start_time=request_ts,
+                    )
+
+                # response.message_retrieval_function = client.message_retrieval
+                # check the filter
+                pass_filter = filter_func is None or filter_func(context=context, response=response)
+                if pass_filter or i == last:
+                    return response
+                continue  # filter is not passed; try the next config
+        raise RuntimeError("Should not reach here.")
+
+    def extract_text_or_completion_object(
+            cls, response: ModelClient.ModelClientResponseProtocol
+    ) -> Union[List[str], List[ModelClient.ModelClientResponseProtocol.Choice.Message]]:
+        """Extract the text or ChatCompletion objects from a completion or chat response.
+
+        Args:
+            response (ChatCompletion | Completion): The response from openai.
+
+        Returns:
+            A list of text, or a list of ChatCompletion objects if function_call/tool_calls are present.
+        """
+        return [response]

--- a/aios/sdk/autogen/client_adapter.py
+++ b/aios/sdk/autogen/client_adapter.py
@@ -14,14 +14,15 @@ from autogen.oai.client import LEGACY_DEFAULT_CACHE_SEED, LEGACY_CACHE_DIR, Plac
 from autogen.oai.openai_utils import get_key
 from autogen.runtime_logging import logging_enabled, log_new_wrapper, log_chat_completion
 from openai import APITimeoutError, APIError
-from pyopenagi.agents.agent_process import AgentProcessFactory
 
+from pyopenagi.agents.agent_process import AgentProcessFactory
 from pyopenagi.utils.chat_template import Query
 from pyopenagi.agents.call_core import CallCore
 
 try:
     from autogen import (
-        OpenAIWrapper, ModelClient, Cache
+        ModelClient, 
+        Cache
     )
 except ImportError:
     raise ImportError(
@@ -30,197 +31,186 @@ except ImportError:
     )
 
 logger = logging.getLogger(__name__)
+ERROR = None
 
 
-class AutogenClientAdapter(OpenAIWrapper, CallCore):
-    def __int__(self, *,
-                config_list: Optional[List[Dict[str, Any]]] = None,
-                agent_process_factory: Optional[AgentProcessFactory] = None,
-                agent_name: Optional[str],
-                **base_config: Any):
-        if agent_name and agent_process_factory:
-            CallCore.__init__(self, agent_name, agent_process_factory, "console")
+def adapter_autogen_client_init(self, *,
+                                config_list: Optional[List[Dict[str, Any]]] = None,
+                                agent_process_factory: Optional[AgentProcessFactory] = None,
+                                agent_name: Optional[str],
+                                **base_config: Any):
+    if agent_name and agent_process_factory:
+        self.aios_call = CallCore(agent_name, agent_process_factory, "console")
 
-        if logging_enabled():
-            log_new_wrapper(self, locals())
-        openai_config, extra_kwargs = self._separate_openai_config(base_config)
-        # It's OK if "model" is not provided in base_config or config_list
-        # Because one can provide "model" at `create` time.
+    if logging_enabled():
+        log_new_wrapper(self, locals())
+    _, extra_kwargs = self._separate_openai_config(base_config)
+    # It's OK if "model" is not provided in base_config or config_list
+    # Because one can provide "model" at `create` time.
 
-        self._clients: List[ModelClient] = []
-        self._config_list: List[Dict[str, Any]] = []
+    self._clients: List[ModelClient] = []
+    self._config_list: List[Dict[str, Any]] = []
 
-        self._config_list = [extra_kwargs]
-        self.wrapper_id = id(self)
+    self._config_list = [extra_kwargs]
+    self.wrapper_id = id(self)
 
-    def create(self, **config: Any) -> ModelClient.ModelClientResponseProtocol:
-        if ERROR:
-            raise ERROR
-        invocation_id = str(uuid.uuid4())
-        last = len(self._clients) - 1
-        # Check if all configs in config list are activated
-        non_activated = [
-            client.config["model_client_cls"] for client in self._clients if isinstance(client, PlaceHolderClient)
-        ]
-        if non_activated:
-            raise RuntimeError(
-                f"Model client(s) {non_activated} are not activated. Please register the custom model clients using `register_model_client` or filter them out form the config list."
+
+def adapter_client_create(self, **config: Any) -> ModelClient.ModelClientResponseProtocol:
+    if ERROR:
+        raise ERROR
+    invocation_id = str(uuid.uuid4())
+    last = len(self._clients) - 1
+    # Check if all configs in config list are activated
+    non_activated = [
+        client.config["model_client_cls"] for client in self._clients if isinstance(client, PlaceHolderClient)
+    ]
+    if non_activated:
+        raise RuntimeError(
+            f"Model client(s) {non_activated} are not activated. Please register the custom model clients using `register_model_client` or filter them out form the config list."
+        )
+    for i, client in enumerate([None]):
+        # merge the input config with the i-th config in the config list
+        full_config = {**config, **self._config_list[i]}
+        # separate the config into create_config and extra_kwargs
+        create_config, extra_kwargs = self._separate_create_config(full_config)
+        api_type = extra_kwargs.get("api_type")
+        if api_type and api_type.startswith("azure") and "model" in create_config:
+            create_config["model"] = create_config["model"].replace(".", "")
+        # construct the create params
+        params = self._construct_create_params(create_config, extra_kwargs)
+        # get the cache_seed, filter_func and context
+        cache_seed = extra_kwargs.get("cache_seed", LEGACY_DEFAULT_CACHE_SEED)
+        cache = extra_kwargs.get("cache")
+        filter_func = extra_kwargs.get("filter_func")
+        context = extra_kwargs.get("context")
+        agent = extra_kwargs.get("agent")
+        price = extra_kwargs.get("price", None)
+        if isinstance(price, list):
+            price = tuple(price)
+        elif isinstance(price, float) or isinstance(price, int):
+            logger.warning(
+                "Input price is a float/int. Using the same price for prompt and completion tokens. Use a list/tuple if prompt and completion token prices are different."
             )
-        for i, client in enumerate([None]):
-            # merge the input config with the i-th config in the config list
-            full_config = {**config, **self._config_list[i]}
-            # separate the config into create_config and extra_kwargs
-            create_config, extra_kwargs = self._separate_create_config(full_config)
-            api_type = extra_kwargs.get("api_type")
-            if api_type and api_type.startswith("azure") and "model" in create_config:
-                create_config["model"] = create_config["model"].replace(".", "")
-            # construct the create params
-            params = self._construct_create_params(create_config, extra_kwargs)
-            # get the cache_seed, filter_func and context
-            cache_seed = extra_kwargs.get("cache_seed", LEGACY_DEFAULT_CACHE_SEED)
-            cache = extra_kwargs.get("cache")
-            filter_func = extra_kwargs.get("filter_func")
-            context = extra_kwargs.get("context")
-            agent = extra_kwargs.get("agent")
-            price = extra_kwargs.get("price", None)
-            if isinstance(price, list):
-                price = tuple(price)
-            elif isinstance(price, float) or isinstance(price, int):
-                logger.warning(
-                    "Input price is a float/int. Using the same price for prompt and completion tokens. Use a list/tuple if prompt and completion token prices are different."
-                )
 
-            cache_client = None
-            if cache is not None:
-                # Use the cache object if provided.
-                cache_client = cache
-            elif cache_seed is not None:
-                # Legacy cache behavior, if cache_seed is given, use DiskCache.
-                cache_client = Cache.disk(cache_seed, LEGACY_CACHE_DIR)
+        cache_client = None
+        if cache is not None:
+            # Use the cache object if provided.
+            cache_client = cache
+        elif cache_seed is not None:
+            # Legacy cache behavior, if cache_seed is given, use DiskCache.
+            cache_client = Cache.disk(cache_seed, LEGACY_CACHE_DIR)
 
-            if cache_client is not None:
-                with cache_client as cache:
-                    # Try to get the response from cache
-                    key = get_key(params)
-                    request_ts = get_current_ts()
-
-                    response: ModelClient.ModelClientResponseProtocol = cache.get(key, None)
-
-                    if response is not None:
-                        # response.message_retrieval_function = client.message_retrieval
-                        # try:
-                        #     response.cost  # type: ignore [attr-defined]
-                        # except AttributeError:
-                        #     # update attribute if cost is not calculated
-                        #     response.cost = client.cost(response)
-                        #     cache.set(key, response)
-                        # total_usage = client.get_usage(response)
-
-                        if logging_enabled():
-                            # Log the cache hit
-                            # TODO: log the config_id and pass_filter etc.
-                            log_chat_completion(
-                                invocation_id=invocation_id,
-                                client_id=id(client),
-                                wrapper_id=id(self),
-                                agent=agent,
-                                request=params,
-                                response=response,
-                                is_cached=1,
-                                cost=response.cost,
-                                start_time=request_ts,
-                            )
-
-                        # check the filter
-                        pass_filter = filter_func is None or filter_func(context=context, response=response)
-                        if pass_filter or i == last:
-                            # Return the response if it passes the filter or it is the last client
-                            # response.config_id = i
-                            # response.pass_filter = pass_filter
-                            # self._update_usage(actual_usage=actual_usage, total_usage=total_usage)
-                            return response
-                        continue  # filter is not passed; try the next config
-            try:
+        if cache_client is not None:
+            with cache_client as cache:
+                # Try to get the response from cache
+                key = get_key(params)
                 request_ts = get_current_ts()
-                response, start_times, end_times, waiting_times, turnaround_times = self.get_response(
-                    query=Query(
-                        messages=params['messages'],
-                        tools=(params["tools"] if "tools" in params else None)
-                    )
+
+                response: ModelClient.ModelClientResponseProtocol = cache.get(key, None)
+
+                if response is not None:
+                    # response.message_retrieval_function = client.message_retrieval
+                    # try:
+                    #     response.cost  # type: ignore [attr-defined]
+                    # except AttributeError:
+                    #     # update attribute if cost is not calculated
+                    #     response.cost = client.cost(response)
+                    #     cache.set(key, response)
+                    # total_usage = client.get_usage(response)
+
+                    if logging_enabled():
+                        # Log the cache hit
+                        # TODO: log the config_id and pass_filter etc.
+                        log_chat_completion(
+                            invocation_id=invocation_id,
+                            client_id=id(client),
+                            wrapper_id=id(self),
+                            agent=agent,
+                            request=params,
+                            response=response,
+                            is_cached=1,
+                            cost=response.cost,
+                            start_time=request_ts,
+                        )
+
+                    # check the filter
+                    pass_filter = filter_func is None or filter_func(context=context, response=response)
+                    if pass_filter or i == last:
+                        return response
+                    continue  # filter is not passed; try the next config
+        try:
+            request_ts = get_current_ts()
+            response, start_times, end_times, waiting_times, turnaround_times = self.aios_call.get_response(
+                query=Query(
+                    messages=params['messages'],
+                    tools=(params["tools"] if "tools" in params else None)
                 )
-                response = {'content': response.response_message, 'tool_calls': response.tool_calls}
-            except APITimeoutError as err:
-                logger.debug(f"config {i} timed out", exc_info=True)
-                if i == last:
-                    raise TimeoutError(
-                        "OpenAI API call timed out. This could be due to congestion or too small a timeout value. The timeout can be specified by setting the 'timeout' value (in seconds) in the llm_config (if you are using agents) or the OpenAIWrapper constructor (if you are using the OpenAIWrapper directly)."
-                    ) from err
-            except APIError as err:
-                error_code = getattr(err, "code", None)
-                if logging_enabled():
-                    log_chat_completion(
-                        invocation_id=invocation_id,
-                        client_id=id(client),
-                        wrapper_id=id(self),
-                        agent=agent,
-                        request=params,
-                        response=f"error_code:{error_code}, config {i} failed",
-                        is_cached=0,
-                        cost=0,
-                        start_time=request_ts,
-                    )
+            )
+            response = {'content': response.response_message, 'tool_calls': response.tool_calls}
+        except APITimeoutError as err:
+            logger.debug(f"config {i} timed out", exc_info=True)
+            if i == last:
+                raise TimeoutError(
+                    "OpenAI API call timed out. This could be due to congestion or too small a timeout value. The timeout can be specified by setting the 'timeout' value (in seconds) in the llm_config (if you are using agents) or the OpenAIWrapper constructor (if you are using the OpenAIWrapper directly)."
+                ) from err
+        except APIError as err:
+            error_code = getattr(err, "code", None)
+            if logging_enabled():
+                log_chat_completion(
+                    invocation_id=invocation_id,
+                    client_id=id(client),
+                    wrapper_id=id(self),
+                    agent=agent,
+                    request=params,
+                    response=f"error_code:{error_code}, config {i} failed",
+                    is_cached=0,
+                    cost=0,
+                    start_time=request_ts,
+                )
 
-                if error_code == "content_filter":
-                    # raise the error for content_filter
-                    raise
-                logger.debug(f"config {i} failed", exc_info=True)
-                if i == last:
-                    raise
-            else:
-                # # add cost calculation before caching no matter filter is passed or not
-                # if price is not None:
-                #     response.cost = self._cost_with_customized_price(response, price)
-                # else:
-                #     response.cost = client.cost(response)
-                # actual_usage = client.get_usage(response)
-                # total_usage = actual_usage.copy() if actual_usage is not None else total_usage
-                # self._update_usage(actual_usage=actual_usage, total_usage=total_usage)
-                if cache_client is not None:
-                    # Cache the response
-                    with cache_client as cache:
-                        cache.set(key, response)
+            if error_code == "content_filter":
+                # raise the error for content_filter
+                raise
+            logger.debug(f"config {i} failed", exc_info=True)
+            if i == last:
+                raise
+        else:
+            if cache_client is not None:
+                # Cache the response
+                with cache_client as cache:
+                    cache.set(key, response)
 
-                if logging_enabled():
-                    # TODO: log the config_id and pass_filter etc.
-                    log_chat_completion(
-                        invocation_id=invocation_id,
-                        client_id=id(client),
-                        wrapper_id=id(self),
-                        agent=agent,
-                        request=params,
-                        response=response,
-                        is_cached=0,
-                        cost=response.cost,
-                        start_time=request_ts,
-                    )
+            if logging_enabled():
+                log_chat_completion(
+                    invocation_id=invocation_id,
+                    client_id=id(client),
+                    wrapper_id=id(self),
+                    agent=agent,
+                    request=params,
+                    response=response,
+                    is_cached=0,
+                    cost=response.cost,
+                    start_time=request_ts,
+                )
 
-                # response.message_retrieval_function = client.message_retrieval
-                # check the filter
-                pass_filter = filter_func is None or filter_func(context=context, response=response)
-                if pass_filter or i == last:
-                    return response
-                continue  # filter is not passed; try the next config
-        raise RuntimeError("Should not reach here.")
+            # response.message_retrieval_function = client.message_retrieval
+            # check the filter
+            pass_filter = filter_func is None or filter_func(context=context, response=response)
+            if pass_filter or i == last:
+                return response
+            continue  # filter is not passed; try the next config
+    raise RuntimeError("Should not reach here.")
 
-    def extract_text_or_completion_object(
-            cls, response: ModelClient.ModelClientResponseProtocol
-    ) -> Union[List[str], List[ModelClient.ModelClientResponseProtocol.Choice.Message]]:
-        """Extract the text or ChatCompletion objects from a completion or chat response.
 
-        Args:
-            response (ChatCompletion | Completion): The response from openai.
+def adapter_client_extract_text_or_completion_object(
+        cls, response: ModelClient.ModelClientResponseProtocol
+) -> Union[List[str], List[ModelClient.ModelClientResponseProtocol.Choice.Message]]:
+    """Extract the text or ChatCompletion objects from a completion or chat response.
 
-        Returns:
-            A list of text, or a list of ChatCompletion objects if function_call/tool_calls are present.
-        """
-        return [response]
+    Args:
+        response (ChatCompletion | Completion): The response from openai.
+
+    Returns:
+        A list of text, or a list of ChatCompletion objects if function_call/tool_calls are present.
+    """
+    return [response]

--- a/aios/utils/id_generator.py
+++ b/aios/utils/id_generator.py
@@ -1,0 +1,7 @@
+import random
+
+
+def generator_tool_call_id():
+    """generate tool call id
+    """
+    return str(random.randint(0, 1000))

--- a/pyopenagi/agents/call_core.py
+++ b/pyopenagi/agents/call_core.py
@@ -1,0 +1,113 @@
+import time
+from threading import Thread
+
+from aios.hooks.stores._global import global_llm_req_queue_add_message
+from .agent_process import AgentProcess
+from ..utils.logger import AgentLogger
+
+
+class CustomizedThread(Thread):
+    def __init__(self, target, args=()):
+        super().__init__()
+        self.target = target
+        self.args = args
+        self.result = None
+
+    def run(self):
+        self.result = self.target(*self.args)
+
+    def join(self):
+        super().join()
+        return self.result
+
+
+class CallCore:
+    """
+    Simplify BaseAgent to provide an interface for external frameworks to make LLM requests using aios.
+    """
+    def __init__(self,
+                 agent_name,
+                 agent_process_factory,
+                 log_mode: str
+                 ):
+        self.agent_name = agent_name
+        self.agent_process_factory = agent_process_factory
+        self.log_mode = log_mode
+        self.logger = self.setup_logger()
+
+    # the default method used for getting response from AIOS
+    def get_response(self,
+                     query,
+                     temperature=0.0
+                     ):
+
+        thread = CustomizedThread(target=self.query_loop, args=(query,))
+        thread.start()
+        return thread.join()
+
+    def query_loop(self, query):
+        agent_process = self.create_agent_request(query)
+
+        completed_response, start_times, end_times, waiting_times, turnaround_times = "", [], [], [], []
+
+        while agent_process.get_status() != "done":
+            thread = Thread(target=self.listen, args=(agent_process,))
+            current_time = time.time()
+            # reinitialize agent status
+            agent_process.set_created_time(current_time)
+            agent_process.set_response(None)
+
+            global_llm_req_queue_add_message(agent_process)
+
+            # LLMRequestQueue.add_message(agent_process)
+
+            thread.start()
+            thread.join()
+
+            completed_response = agent_process.get_response()
+            if agent_process.get_status() != "done":
+                self.logger.log(
+                    f"Suspended due to the reach of time limit ({agent_process.get_time_limit()}s). Current result is: {completed_response.response_message}\n",
+                    level="suspending"
+                )
+            start_time = agent_process.get_start_time()
+            end_time = agent_process.get_end_time()
+            waiting_time = start_time - agent_process.get_created_time()
+            turnaround_time = end_time - agent_process.get_created_time()
+
+            start_times.append(start_time)
+            end_times.append(end_time)
+            waiting_times.append(waiting_time)
+            turnaround_times.append(turnaround_time)
+            # Re-start the thread if not done
+
+        # self.agent_process_factory.deactivate_agent_process(agent_process.get_pid())
+
+        return completed_response, start_times, end_times, waiting_times, turnaround_times
+
+    def create_agent_request(self, query):
+        agent_process = self.agent_process_factory.activate_agent_process(
+            agent_name=self.agent_name,
+            query=query
+        )
+        agent_process.set_created_time(time.time())
+        # print("Already put into the queue")
+        return agent_process
+
+    def listen(self, agent_process: AgentProcess):
+        """Response Listener for agent
+
+        Args:
+            agent_process (AgentProcess): Listened AgentProcess
+
+        Returns:
+            str: LLM response of Agent Process
+        """
+        while agent_process.get_response() is None:
+            time.sleep(0.2)
+
+        return agent_process.get_response()
+
+    def setup_logger(self):
+        logger = AgentLogger(self.agent_name, self.log_mode)
+        return logger

--- a/scripts/aios-autogen/example_aios_autogen_chat.py
+++ b/scripts/aios-autogen/example_aios_autogen_chat.py
@@ -1,0 +1,86 @@
+# This is a main script that tests the functionality of specific agents.
+# It requires no user input.
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import warnings
+from dotenv import load_dotenv
+from aios.sdk.autogen.adapater import prepare_autogen
+from aios.hooks.llm import useKernel, useFIFOScheduler
+from aios.utils.utils import delete_directories
+from aios.utils.utils import (
+    parse_global_args,
+)
+from pyopenagi.agents.agent_process import AgentProcessFactory
+
+from autogen import ConversableAgent, UserProxyAgent
+
+
+def clean_cache(root_directory):
+    targets = {
+        ".ipynb_checkpoints",
+        "__pycache__",
+        ".pytest_cache",
+        "context_restoration",
+    }
+    delete_directories(root_directory, targets)
+
+
+def main():
+    # parse arguments and set configuration for this run accordingly
+    warnings.filterwarnings("ignore")
+    parser = parse_global_args()
+    args = parser.parse_args()
+
+    llm_name = args.llm_name
+    max_gpu_memory = args.max_gpu_memory
+    eval_device = args.eval_device
+    max_new_tokens = args.max_new_tokens
+    scheduler_log_mode = args.scheduler_log_mode
+    # agent_log_mode = args.agent_log_mode
+    llm_kernel_log_mode = args.llm_kernel_log_mode
+    use_backend = args.use_backend
+    load_dotenv()
+
+    llm = useKernel(
+        llm_name=llm_name,
+        max_gpu_memory=max_gpu_memory,
+        eval_device=eval_device,
+        max_new_tokens=max_new_tokens,
+        log_mode=llm_kernel_log_mode,
+        use_backend=use_backend
+    )
+
+    # run agents concurrently for maximum efficiency using a scheduler
+
+    # scheduler = FIFOScheduler(llm=llm, log_mode=scheduler_log_mode)
+
+    startScheduler, stopScheduler = useFIFOScheduler(
+        llm=llm,
+        log_mode=scheduler_log_mode,
+        get_queue_message=None
+    )
+
+    process_factory = AgentProcessFactory()
+    prepare_autogen(process_factory)
+
+    # Create the agent that uses the LLM.
+    assistant = ConversableAgent("agent")
+
+    # Create the agent that represents the user in the conversation.
+    user_proxy = UserProxyAgent("user", code_execution_config=False)
+
+    startScheduler()
+
+    # Let the assistant start the conversation.  It will end when the user types exit.
+    assistant.initiate_chat(user_proxy, message="How can I help you today?")
+
+    stopScheduler()
+
+    clean_cache(root_directory="./")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/aios-autogen/example_aios_autogen_code.py
+++ b/scripts/aios-autogen/example_aios_autogen_code.py
@@ -2,6 +2,7 @@
 # It requires no user input.
 import sys
 import os
+import tempfile
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
@@ -13,9 +14,8 @@ from aios.utils.utils import delete_directories
 from aios.utils.utils import (
     parse_global_args,
 )
-from pyopenagi.agents.agent_process import AgentProcessFactory
-
-from autogen import ConversableAgent, UserProxyAgent
+from autogen import ConversableAgent
+from autogen.coding import LocalCommandLineCodeExecutor
 
 
 def clean_cache(root_directory):
@@ -63,22 +63,47 @@ def main():
         get_queue_message=None
     )
 
-    process_factory = AgentProcessFactory()
+    # Create a temporary directory to store the code files.
+    temp_dir = tempfile.TemporaryDirectory()
 
-    prepare_autogen(process_factory)
+    # Create a local command line code executor.
+    executor = LocalCommandLineCodeExecutor(
+        timeout=10,  # Timeout for each code execution in seconds.
+        work_dir=temp_dir.name,  # Use the temporary directory to store the code files.
+    )
 
-    # Create the agent that uses the LLM.
-    assistant = ConversableAgent("agent")
+    # Create an agent with code executor configuration.
+    code_executor_agent = ConversableAgent(
+        "code_executor_agent",
+        code_execution_config={"executor": executor},  # Use the local command line code executor.
+        human_input_mode="ALWAYS",  # Always take human input for this agent for safety.
+    )
 
-    # Create the agent that represents the user in the conversation.
-    user_proxy = UserProxyAgent("user", code_execution_config=False)
+    prepare_autogen()
 
     startScheduler()
 
-    # Let the assistant start the conversation.  It will end when the user types exit.
-    assistant.initiate_chat(user_proxy, message="How can I help you today?")
+    message_with_code_block = """This is a message with code block.
+    The code block is below:
+    ```python
+import numpy as np
+import matplotlib.pyplot as plt
+x = np.random.randint(0, 100, 100)
+y = np.random.randint(0, 100, 100)
+plt.scatter(x, y)
+plt.savefig('scatter.png')
+print('Scatter plot saved to scatter.png')
+    ```
+    This is the end of the message.
+    """
+
+    # Generate a reply for the given code.
+    reply = code_executor_agent.generate_reply(messages=[{"role": "user", "content": message_with_code_block}])
+    temp_dir.cleanup()
 
     stopScheduler()
+
+    print(reply)
 
     clean_cache(root_directory="./")
 

--- a/scripts/aios-autogen/example_aios_autogen_tool.py
+++ b/scripts/aios-autogen/example_aios_autogen_tool.py
@@ -87,7 +87,6 @@ def main():
         system_message="You are a helpful AI assistant. "
                        "You can help with simple calculations. "
                        "Return 'TERMINATE' when the task is done.",
-        agent_process_factory=process_factory
     )
 
     # The user proxy agent is used for interacting with the assistant agent

--- a/scripts/aios-autogen/example_aios_autogen_tool.py
+++ b/scripts/aios-autogen/example_aios_autogen_tool.py
@@ -79,7 +79,7 @@ def main():
 
     process_factory = AgentProcessFactory()
 
-    prepare_autogen(process_factory)
+    prepare_autogen()
 
     # Let's first define the assistant agent that suggests tool calls.
     assistant = ConversableAgent(
@@ -87,12 +87,14 @@ def main():
         system_message="You are a helpful AI assistant. "
                        "You can help with simple calculations. "
                        "Return 'TERMINATE' when the task is done.",
+        agent_process_factory = process_factory
     )
 
     # The user proxy agent is used for interacting with the assistant agent
     # and executes tool calls.
     user_proxy = ConversableAgent(
         name="User",
+        llm_config=False,
         is_termination_msg=lambda msg: msg.get("content") is not None and "TERMINATE" in msg["content"],
         human_input_mode="NEVER",
     )

--- a/scripts/aios-autogen/example_aios_autogen_twoagent.py
+++ b/scripts/aios-autogen/example_aios_autogen_twoagent.py
@@ -13,9 +13,8 @@ from aios.utils.utils import delete_directories
 from aios.utils.utils import (
     parse_global_args,
 )
+from autogen import ConversableAgent
 from pyopenagi.agents.agent_process import AgentProcessFactory
-
-from autogen import ConversableAgent, UserProxyAgent
 
 
 def clean_cache(root_directory):
@@ -67,18 +66,26 @@ def main():
 
     prepare_autogen(process_factory)
 
-    # Create the agent that uses the LLM.
-    assistant = ConversableAgent("agent")
+    cathy = ConversableAgent(
+        "cathy",
+        system_message="Your name is Cathy and you are a part of a duo of comedians.",
+        human_input_mode="NEVER",  # Never ask for human input.
+    )
 
-    # Create the agent that represents the user in the conversation.
-    user_proxy = UserProxyAgent("user", code_execution_config=False)
+    joe = ConversableAgent(
+        "joe",
+        system_message="Your name is Joe and you are a part of a duo of comedians.",
+        human_input_mode="NEVER",  # Never ask for human input.
+    )
 
     startScheduler()
 
     # Let the assistant start the conversation.  It will end when the user types exit.
-    assistant.initiate_chat(user_proxy, message="How can I help you today?")
+    result = joe.initiate_chat(cathy, message="How can I help you today?", max_turns=2)
 
     stopScheduler()
+
+    print(result)
 
     clean_cache(root_directory="./")
 


### PR DESCRIPTION
- **Add Autogen Adapter**: Introduce an autogen adapter to allow agents developed with autogen to operate on AIOS, while preserving a usage pattern that closely mirrors autogen. Simply add the line ·prepare_autogen(agent_process_factory: Optional[AgentProcessFactory])` before your autogen code then you can run your code on aios. Examples can be found in the aios/scripts/aios-autogen/ path.
- **Ollama Support Tool Call Like GPT**: This means that when making an Ollama request on AIOS, the tool call mechanism using tool_call_id and the 'tool' role is supported.

(Additional documentation may be provided in future updates.)