### PR TITLE
Fixed hardcoded URL to AIOS chat on local environments

### DIFF
--- a/agenthub/app/chat/page.tsx
+++ b/agenthub/app/chat/page.tsx
@@ -40,7 +40,7 @@ const ChatInterface: React.FC = () => {
   function parseText(input: string): string {
     // Step 1: Replace mention spans with the custom format
     let parsed = input.replace(/<span class="mention" data-type="mention" data-id="([^"]+)">@[^<]+<\/span>/g, '?>>$1/?>>');
-    
+
     // Step 2: Convert <br> tags to newlines
     parsed = parsed.replace(/<br[^>]*>/g, '\n');
 
@@ -67,7 +67,7 @@ const ChatInterface: React.FC = () => {
     // Regular expression to match the pattern ?>>Name/?>>\s*Content
     const regex = /\?>>(.*?)\/?>>([^?]*)/g;
     const results = [];
-    
+
     // Find all matches
     let match;
     while ((match = regex.exec(inputString)) !== null) {
@@ -79,15 +79,6 @@ const ChatInterface: React.FC = () => {
       results.push({
         name,
         content
-      });
-    }
-    
-    // Handle cases where there is no agent mentioned
-    if (!(results.length > 0)) {
-      results.push({
-        // Must add base agent here
-        name: "example/academic_agent",
-        content: inputString,
       });
     }
 
@@ -126,7 +117,7 @@ const ChatInterface: React.FC = () => {
 
       setMessages(prevMessages => [...prevMessages, botMessage]);
 
-      const res = await processAgentCommand(parseNamedContent(parseText(content))[0] as AgentCommand)
+      const res = await _(parseNamedContent(parseText(content))[0] as AgentCommand)
 
       setMessages(prevMessages => [...prevMessages].map(message => {
         if (message.id == messageId) {
@@ -145,7 +136,7 @@ const ChatInterface: React.FC = () => {
     setActiveChat(newChat.id);
   };
 
-  const processAgentCommand = async (command: AgentCommand) => {
+  const _ = async (command: AgentCommand) => {
     const addAgentResponse = await axios.post(`${baseUrl}/api/proxy`, {
       type: 'POST',
       url: `${serverUrl}/add_agent`,

--- a/agenthub/app/chat/page.tsx
+++ b/agenthub/app/chat/page.tsx
@@ -40,7 +40,7 @@ const ChatInterface: React.FC = () => {
   function parseText(input: string): string {
     // Step 1: Replace mention spans with the custom format
     let parsed = input.replace(/<span class="mention" data-type="mention" data-id="([^"]+)">@[^<]+<\/span>/g, '?>>$1/?>>');
-
+    
     // Step 2: Convert <br> tags to newlines
     parsed = parsed.replace(/<br[^>]*>/g, '\n');
 
@@ -67,7 +67,7 @@ const ChatInterface: React.FC = () => {
     // Regular expression to match the pattern ?>>Name/?>>\s*Content
     const regex = /\?>>(.*?)\/?>>([^?]*)/g;
     const results = [];
-
+    
     // Find all matches
     let match;
     while ((match = regex.exec(inputString)) !== null) {
@@ -79,6 +79,15 @@ const ChatInterface: React.FC = () => {
       results.push({
         name,
         content
+      });
+    }
+    
+    // Handle cases where there is no agent mentioned
+    if (!(results.length > 0)) {
+      results.push({
+        // Must add base agent here
+        name: "example/academic_agent",
+        content: inputString,
       });
     }
 
@@ -117,7 +126,7 @@ const ChatInterface: React.FC = () => {
 
       setMessages(prevMessages => [...prevMessages, botMessage]);
 
-      const res = await _(parseNamedContent(parseText(content))[0] as AgentCommand)
+      const res = await processAgentCommand(parseNamedContent(parseText(content))[0] as AgentCommand)
 
       setMessages(prevMessages => [...prevMessages].map(message => {
         if (message.id == messageId) {
@@ -136,7 +145,7 @@ const ChatInterface: React.FC = () => {
     setActiveChat(newChat.id);
   };
 
-  const _ = async (command: AgentCommand) => {
+  const processAgentCommand = async (command: AgentCommand) => {
     const addAgentResponse = await axios.post(`${baseUrl}/api/proxy`, {
       type: 'POST',
       url: `${serverUrl}/add_agent`,

--- a/agenthub/components/homepage/Products.tsx
+++ b/agenthub/components/homepage/Products.tsx
@@ -4,6 +4,7 @@ import { Link } from '@nextui-org/react'
 import SectionContainer from './SectionContainer'
 import ExampleCard from './ExampleCard'
 
+const isDevEnv = process.env.NODE_ENV == "development"
 
 const Examples = [
     {
@@ -33,157 +34,11 @@ const Examples = [
       author_url: 'https://github.com/supabase',
       author_img: 'https://avatars.githubusercontent.com/u/54469796',
       repo_name: 'vercel/next.js/examples/with-supabase',
-      repo_url: 'https://my.aios.foundation/chat',
+      repo_url: (isDevEnv ? 'http://localhost:3000/chat' : 'https://my.aios.foundation/chat'),
       vercel_deploy_url:
         'https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fnext.js%2Ftree%2Fcanary%2Fexamples%2Fwith-supabase&project-name=nextjs-with-supabase&repository-name=nextjs-with-supabase&demo-title=nextjs-with-supabase&demo-description=This%20starter%20configures%20Supabase%20Auth%20to%20use%20cookies%2C%20making%20the%20user%27s%20session%20available%20throughout%20the%20entire%20Next.js%20app%20-%20Client%20Components%2C%20Server%20Components%2C%20Route%20Handlers%2C%20Server%20Actions%20and%20Middleware.&demo-url=https%3A%2F%2Fdemo-nextjs-with-supabase.vercel.app%2F&external-id=https%3A%2F%2Fgithub.com%2Fvercel%2Fnext.js%2Ftree%2Fcanary%2Fexamples%2Fwith-supabase&demo-image=https%3A%2F%2Fdemo-nextjs-with-supabase.vercel.app%2Fopengraph-image.png&integration-ids=oac_VqOgBHqhEoFTPzGkPd7L0iH6',
       demo_url: 'https://demo-nextjs-with-supabase.vercel.app/',
-    },
-    {
-      type: 'example',
-      tags: ['Next.js', 'OpenAI', 'Vercel'],
-      products: [],
-      title: 'AI Chatbot',
-      description:
-        'An open-source AI chatbot app template built with Next.js, the Vercel AI SDK, OpenAI, and Supabase.',
-      author: 'Supabase',
-      author_url: 'https://github.com/supabase',
-      author_img: 'https://avatars.githubusercontent.com/u/54469796',
-      repo_name: 'supabase-community/vercel-ai-chatbot',
-      repo_url: 'https://github.com/supabase-community/vercel-ai-chatbot',
-      vercel_deploy_url:
-        'https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fsupabase-community%2Fvercel-ai-chatbot&env=OPENAI_API_KEY&envDescription=You%20must%20first%20activate%20a%20Billing%20Account%20here%3A%20https%3A%2F%2Fplatform.openai.com%2Faccount%2Fbilling%2Foverview&envLink=https%3A%2F%2Fplatform.openai.com%2Faccount%2Fapi-keys&project-name=vercel-ai-chatbot-with-supabase&repository-name=vercel-ai-chatbot-with-supabase&integration-ids=oac_VqOgBHqhEoFTPzGkPd7L0iH6&external-id=https%3A%2F%2Fgithub.com%2Fsupabase-community%2Fvercel-ai-chatbot%2Ftree%2Fmain',
-      demo_url: '',
-    },
-    {
-      type: 'example',
-      tags: ['LangChain', 'Next.js'],
-      products: [],
-      title: 'LangChain + Next.js Starter',
-      description:
-        'Starter template and example use-cases for LangChain projects in Next.js, including chat, agents, and retrieval.',
-      author: 'Supabase',
-      author_url: 'https://github.com/supabase',
-      author_img: 'https://avatars.githubusercontent.com/u/54469796',
-      repo_name: 'langchain-ai/langchain-nextjs-template',
-      repo_url: 'https://github.com/langchain-ai/langchain-nextjs-template',
-      vercel_deploy_url:
-        'https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flangchain-ai%2Flangchain-nextjs-template',
-      demo_url: 'https://langchain-nextjs-template.vercel.app/',
-    },
-    {
-      type: 'example',
-      tags: ['Flutter'],
-      products: [],
-      title: 'Flutter User Management',
-      description:
-        'Get started with Supabase and Flutter by building a user management app with auth, file storage, and database.',
-      author: 'Supabase Community',
-      author_url: 'https://github.com/supabase-community',
-      author_img: 'https://avatars.githubusercontent.com/u/87650496',
-      repo_name: 'supabase/examples/user-management/flutter-user-management',
-      repo_url:
-        'https://github.com/supabase/supabase/tree/master/examples/user-management/flutter-user-management',
-      vercel_deploy_url: '',
-      demo_url: '',
-    },
-    {
-      type: 'example',
-      tags: ['Expo'],
-      products: [],
-      title: 'Expo React Native Starter',
-      description:
-        'An extended version of create-t3-turbo implementing authentication on both the web and mobile applications.',
-      author: 'Supabase Community',
-      author_url: 'https://github.com/supabase-community',
-      author_img: 'https://avatars.githubusercontent.com/u/87650496',
-      repo_name: 'supabase-community/create-t3-turbo',
-      repo_url: 'https://github.com/supabase-community/create-t3-turbo',
-      vercel_deploy_url: '',
-      demo_url: 'https://create-t3-turbo.vercel.app/',
-    },
-    {
-      type: 'example',
-      tags: ['Svelte'],
-      products: [],
-      title: 'Svelte kanban board',
-      description: 'A Trello clone using Supabase as the storage system.',
-      author: 'joshnuss',
-      author_url: 'https://github.com/joshnuss',
-      author_img: 'https://avatars.githubusercontent.com/u/4437',
-      repo_name: 'supabase-kanban',
-      repo_url: 'https://github.com/joshnuss/supabase-kanban',
-      vercel_deploy_url: '',
-      demo_url: 'https://supabase-kanban.vercel.app/',
-    },
-    {
-      type: 'example',
-      tags: ['Next.js'],
-      products: [],
-      title: 'Next.js Realtime chat app',
-      description: 'Next.js Slack clone app using Supabase realtime subscriptions',
-      author: 'supabase',
-      author_url: 'https://github.com/supabase',
-      author_img: 'https://avatars.githubusercontent.com/u/54469796',
-      repo_name: 'nextjs-slack-clone',
-      repo_url:
-        'https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone',
-      vercel_deploy_url: '',
-      demo_url: '',
-    },
-    {
-      type: 'example',
-      tags: ['Next.js'],
-      products: [],
-      title: 'Next.js Subscription and Auth',
-      description: 'The all-in-one starter kit for high-performance SaaS applications.',
-      author: 'Vercel',
-      author_url: 'https://github.com/vercel',
-      author_img: 'https://avatars.githubusercontent.com/u/14985020',
-      repo_name: 'nextjs-subscription-payments',
-      repo_url: 'https://github.com/vercel/nextjs-subscription-payments',
-      vercel_deploy_url:
-        'https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fnextjs-subscription-payments&env=NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,STRIPE_SECRET_KEY&envDescription=Enter%20your%20Stripe%20API%20keys.&envLink=https%3A%2F%2Fdashboard.stripe.com%2Fapikeys&project-name=nextjs-subscription-payments&repository-name=nextjs-subscription-payments&integration-ids=oac_VqOgBHqhEoFTPzGkPd7L0iH6&external-id=https%3A%2F%2Fgithub.com%2Fvercel%2Fnextjs-subscription-payments%2Ftree%2Fmain',
-      demo_url: 'https://subscription-payments.vercel.app/',
-    },
-    {
-      type: 'example',
-      tags: ['Expo', 'React'],
-      products: [],
-      title: 'Expo React Native Starter',
-      description: 'Template bottom tabs with auth flow (Typescript)',
-      author: 'codingki',
-      author_url: 'https://github.com/codingki',
-      author_img: 'https://avatars.githubusercontent.com/u/39829726',
-      repo_name: 'react-native-expo-template',
-      repo_url:
-        'https://github.com/codingki/react-native-expo-template/tree/master/template-typescript-bottom-tabs-supabase-auth-flow',
-      vercel_deploy_url: '',
-      demo_url: '',
-    },
-    {
-      type: 'example',
-      tags: ['NestJs'],
-      products: [],
-      title: 'NestJS example',
-      description: 'NestJS example using Supabase Auth',
-      author: 'hiro1107',
-      author_url: 'https://github.com/hiro1107',
-      author_img: 'https://avatars.githubusercontent.com/u/1423067',
-      repo_name: 'nestjs-supabase-auth',
-      repo_url: 'https://github.com/hiro1107/nestjs-supabase-auth',
-      vercel_deploy_url: '',
-      demo_url: '',
-    },
-  
-    // {
-    //   type: 'example',
-    //   tags: ['Supabase'],
-    //   products: [PRODUCT_NAMES.FUNCTIONS],
-    //   title: 'With supabase-js',
-    //   description: 'Use the Supabase client inside your Edge Function.',
-    //   repo_url: 'https://supabase.com/docs/guides/functions/auth',
-    // },
-   
+    }
   ]
 
 const BuiltWithSupabase = () => {


### PR DESCRIPTION
Hardcoded URL leads user using AIOS locally to the live version at https://my.aios.foundation/chat.

Also removed unused entries. Speeds up compilation time

EDIT: I also accidentally included a commit that defaults the agent to @example/academic_agent if no agent is provided as the WebUI does not work without a mention. I’ll separate this into another draft when I come home today, but if someone reviews this early please take this in mind. I plan to write a draft for doing more structured inputting of the chat command instead of using regex to parse after the fact