### PR TITLE
Change production to Gemini

### DIFF
--- a/aios_config.json
+++ b/aios_config.json
@@ -1,7 +1,7 @@
 {
     "llm_cores": [
         {
-            "llm_name": "gpt-4o-mini",
+            "llm_name": "gemini-1.5-flash",
             "use_backend": "openai",
             "max_new_tokens": 1024
         }

--- a/aios_config.json
+++ b/aios_config.json
@@ -2,7 +2,7 @@
     "llm_cores": [
         {
             "llm_name": "gemini-1.5-flash",
-            "use_backend": "openai",
+            "use_backend": "google",
             "max_new_tokens": 1024
         }
     ]


### PR DESCRIPTION
Currently inference is not rate-limited. As a stopgap measure, this PR changes the production endpoint to Gemini

NOTE: GEMINI_API_KEY must be set on production server before merging