### PR TITLE
docs: added documentation for web quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,17 @@ CUDA_VISIBLE_DEVICES=0 python main.py --llm_name meta-llama/Meta-Llama-3-8B-Inst
 ##### Node
 - Supported versions: **LTS** support ONLY
 
+you can check that you meet requirements by running
+```bash
+py -v
+```
+and
+```bash
+npm -v
+```
+in your terminal
+
+
 Run the launch.py to start both the frontend and backend
 ```
 python launch.py

--- a/agenthub/app/chat/page.tsx
+++ b/agenthub/app/chat/page.tsx
@@ -117,7 +117,7 @@ const ChatInterface: React.FC = () => {
 
       setMessages(prevMessages => [...prevMessages, botMessage]);
 
-      const res = await _(parseNamedContent(parseText(content))[0] as AgentCommand)
+      const res = await processAgentCommand(parseNamedContent(parseText(content))[0] as AgentCommand)
 
       setMessages(prevMessages => [...prevMessages].map(message => {
         if (message.id == messageId) {
@@ -136,7 +136,15 @@ const ChatInterface: React.FC = () => {
     setActiveChat(newChat.id);
   };
 
-  const _ = async (command: AgentCommand) => {
+  const processAgentCommand = async (command: AgentCommand) => {
+    // Temporary measure to prevent hanging until draft is published
+    if (!command) {
+      return {
+        name: undefined,
+        content: "You must provide a mention to use AIOS. (@example/...)",
+      }
+    }
+
     const addAgentResponse = await axios.post(`${baseUrl}/api/proxy`, {
       type: 'POST',
       url: `${serverUrl}/add_agent`,

--- a/docs/source/get_started/web_quickstart.rst
+++ b/docs/source/get_started/web_quickstart.rst
@@ -1,0 +1,43 @@
+.. _web_quickstart:
+
+Web Quickstart
+==============
+Be sure to complete the :ref:`installation instructions <aios_installation>` before continuing with this guide.
+
+Requirements
+------------
+* Python: 3.9-3.11
+* NPM
+
+check you meet the requirements by running the following commands in your terminal
+.. tip::
+
+        depending on your machine python might be called as "python" or "python3"
+
+.. code-block:: console
+
+        py -v
+
+
+and
+.. code-block:: console
+
+        npm -v
+
+
+Starting the Web Interface
+--------------------------
+the front-end and back-end will both be compilled when you call
+.. code-block:: console
+
+        py launch.py
+
+in the terminal
+
+this should open a window in your default browser, however if it doesnt, navigate to `https://localhost:3000`
+
+.. tip::
+
+        some users will find the webpage displaying errors, 99% of the time this is an issue with building before compiling and is solved by reloading
+
+from here you can interact with agents using '@' to select agents.

--- a/docs/source/get_started/web_quickstart.rst
+++ b/docs/source/get_started/web_quickstart.rst
@@ -38,7 +38,7 @@ the front-end and back-end will both be compilled when you call
 
 in the terminal
 
-this should open a window in your default browser, however if it doesnt, navigate to `https://localhost:3000`
+this should open a window in your default browser, however if it doesnt, navigate to https://localhost:3000
 
 .. tip::
 

--- a/docs/source/get_started/web_quickstart.rst
+++ b/docs/source/get_started/web_quickstart.rst
@@ -10,9 +10,11 @@ Requirements
 * NPM
 
 check you meet the requirements by running the following commands in your terminal
+
 .. tip::
 
         depending on your machine python might be called as "python" or "python3"
+
 
 .. code-block:: console
 
@@ -20,6 +22,7 @@ check you meet the requirements by running the following commands in your termin
 
 
 and
+
 .. code-block:: console
 
         npm -v
@@ -28,6 +31,7 @@ and
 Starting the Web Interface
 --------------------------
 the front-end and back-end will both be compilled when you call
+
 .. code-block:: console
 
         py launch.py


### PR DESCRIPTION
The current documentation does not cover the web interface in its getting started folder

this will add a file describing the process and common bugs as well as addressing my issue with a reminder in the README file