### PR TITLE
fix: Resolve mention dropdown issue in @ agent selection for light mode

### DIFF
--- a/agenthub/public/MentionListV2Light.scss
+++ b/agenthub/public/MentionListV2Light.scss
@@ -19,6 +19,10 @@
       text-align: left;
       width: 100%;
   
+      .item-text {
+        color: #000000 !important;
+      }
+
       &:hover,
       &:hover.is-selected {
         background-color: var(--gray-3);


### PR DESCRIPTION
Bug Fix: Resolved an issue where the mention dropdown was not displaying names properly in the @ agent selection, specifically in light mode.
Root Cause: The dropdown styling was not compatible with the light mode theme, leading to invisible or misaligned text.
Solution: Adjusted CSS styles and ensured compatibility across themes (light and dark modes).
Testing: Verified functionality in both light and dark modes to ensure the dropdown displays names correctly.
<img width="1693" alt="Screenshot 2024-11-15 at 8 44 01 PM" src="https://github.com/user-attachments/assets/9a783d03-d1f3-4924-a46f-fe6a906b66b5">

