### PR TITLE
fix: use locally hosted kernel in development environments

### DIFF
--- a/agenthub/lib/env.ts
+++ b/agenthub/lib/env.ts
@@ -2,5 +2,5 @@ export const inDevEnvironment = !!process && process.env.NODE_ENV === 'developme
 // export const serverUrl = inDevEnvironment ? 'http://localhost:8000' : 'https://myapp-y5z35kuonq-uk.a.run.app'
 export const baseUrl = inDevEnvironment ? 'http://localhost:3000' : 'https://my.aios.foundation'
 // export const serverUrl = inDevEnvironment ? 'http://localhost:8000' : 'http://35.232.56.61:8000'
-export const serverUrl = 'http://35.232.56.61:8000';
+export const serverUrl = inDevEnvironment ? 'http://localhost:8000' : 'http://35.232.56.61:8000';
 


### PR DESCRIPTION
WebUI is hardcoded to live server. This PR instead uses the localhost kernel server when running in a development environment.