### PR TITLE
fix: allow direct running of server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -31,6 +31,7 @@ from dotenv import load_dotenv
 import atexit
 
 import json
+import uvicorn
 
 from pyopenagi.utils.chat_template import LLMQuery
 
@@ -212,3 +213,8 @@ def cleanup():
 
 
 atexit.register(cleanup)
+
+if __name__ == "__main__":
+    config = uvicorn.Config(app, hostname="0.0.0.0", port=8000, log_level="critical")
+    server = uvicorn.Server(config)
+    server.run()


### PR DESCRIPTION
Running server.py directly does not start the server currently, leading to an error if the web server and the kernel are run separately. This PR fixes this.