### PR TITLE
fix: remove hot reloading

### DIFF
--- a/runtime/launch_kernel.sh
+++ b/runtime/launch_kernel.sh
@@ -1,1 +1,1 @@
-python -m uvicorn runtime.kernel:app --reload
+python -m uvicorn runtime.kernel:app


### PR DESCRIPTION
Hot reloading breaks the entire system because file changes are made while inferencing an agent, this PR simply disables hot reload