### PR TITLE
fix: fixed bugs within address_syscall in ollama.py

### DIFF
--- a/aios/llm_core/cores/local/ollama.py
+++ b/aios/llm_core/cores/local/ollama.py
@@ -38,7 +38,7 @@ class OllamaLLM(BaseLLM):
     def address_syscall(self, llm_syscall, temperature=0.0):
         # ensures the models are from ollama
         # print(self.model_name)
-        assert re.search(r"ollama", self.model_name, re.IGNORECASE)
+        # assert re.search(r"ollama", self.model_name, re.IGNORECASE)
 
         """ simple wrapper around ollama functions """
         llm_syscall.set_status("executing")
@@ -72,12 +72,12 @@ class OllamaLLM(BaseLLM):
 
                 else:
                     response = Response(
-                        response_message=response["message"]["content"], finished=True
+                        response_message=chat_result["message"]["content"], finished=True
                     )
 
             except Exception as e:
                 response = Response(
-                    response_message=response["message"]["content"], finished=True
+                    response_message=chat_result["message"]["content"], finished=True
                 )
 
         else:


### PR DESCRIPTION
The following caused the ollama local mode to fail during a normal demo_agent invocation (i.e. the example call).
1) The assert (requiring the name "ollama" within the model_name is unnecessary and actually prevents normal operation). For example using phi3.5:latest in ollama neither has the name ollama in it nor needs that name. Rather than removing it, I've commented it out allowing me to use the phi3.5:latest model. 

2) rather than using the chat_result from line 59, it was using an undefined variable 'response' in two places causing an exception. I have replaced this with chat_result and subsequent test runs shows it to operate as expected.