### PR TITLE
Fix: Add Ollama Support

### DIFF
--- a/.github/workflows/test_ollama.yml
+++ b/.github/workflows/test_ollama.yml
@@ -54,7 +54,18 @@ jobs:
 
     - name: Run Ollama serve
       run: |
-        ollama serve 2>&1 | tee ollama-llm.log
+        ollama serve 2>&1 | tee ollama-llm.log &
+        # Wait for ollama to start
+        for i in {1..30}; do
+          if curl -s http://localhost:11434/api/version > /dev/null; then
+            echo "Ollama is running"
+            break
+          fi
+          echo "Waiting for ollama to start... ($i/30)"
+          sleep 1
+        done
+        # Verify ollama is running
+        curl -s http://localhost:11434/api/version || (echo "Failed to start ollama" && exit 1)
 
     - name: Run AIOS kernel in background
       run: |

--- a/aios/llm_core/local.py
+++ b/aios/llm_core/local.py
@@ -123,3 +123,21 @@ class VLLMLocalBackend:
         result     = response[0].outputs[0].text
 
         return result
+
+class OllamaBackend:
+    def __init__(self, model_name, device="auto", max_gpu_memory=None, hostname=None):
+        self.model_name = model_name
+        self.hostname = hostname or "http://localhost:11434"
+        
+    def __call__(
+        self,
+        messages,
+        temperature,
+        stream=False,
+    ):
+        return str(completion(
+            model="ollama/" + self.model_name,
+            messages=messages,
+            temperature=temperature,
+            api_base=self.hostname
+        ))

--- a/aios/llm_core/strategy.py
+++ b/aios/llm_core/strategy.py
@@ -18,7 +18,7 @@ class RouterStrategy(Enum):
     SIMPLE = 0,
 
 class SimpleStrategy:
-    def __init__(self, llm_name):
+    def __init__(self, llm_name: list[str]):
         self.endpoints = llm_name
         self.idx = 0
 


### PR DESCRIPTION
## What's Changed
- Add OllamaBackend for local LLM support
- Fix environment variable checks in LLMAdapter
- Update test workflow for Ollama integration

## How It Works
1. Add new OllamaBackend class
2. Connect to Ollama server at port 11434
3. Use litellm to handle API calls

## Test Changes
- Add Ollama service health check
- Wait for Ollama to start before tests