### PR TITLE
fix: Docker-ignore `__pycache__` in subdirectories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-__pycache__
+**/__pycache__
 venv
 env
 .github


### PR DESCRIPTION
Fixes #508

This PR fixes a minor .dockerignore misconfiguration. I added `**/` to the pattern `__pycache__` in the .dockerignore file to recursively ignore `__pycache__`.