### PR TITLE
fix(storage): Files not creating in correct folder

### DIFF
--- a/aios/storage/filesystem/lsfs.py
+++ b/aios/storage/filesystem/lsfs.py
@@ -205,8 +205,11 @@ class LSFS:
 
             elif operation_type == "create_file":
                 file_path = agent_request.query.params.get("file_path", None)
+                file_name = agent_request.query.params.get("file_name", None)
                 result = self.sto_create_file(
-                    file_path, collection_name
+                    file_name=file_name,
+                    file_path=file_path,
+                    collection_name=collection_name
                 )
 
             elif operation_type == "create_dir":
@@ -269,6 +272,8 @@ class LSFS:
         try:
             if file_path is None:
                 file_path = os.path.join(self.root_dir, file_name)
+            elif not os.path.isabs(file_path):
+                file_path = os.path.join(self.root_dir, file_path)
 
             if not os.path.exists(file_path):
                 with open(file_path, 'w'):
@@ -286,6 +291,8 @@ class LSFS:
         try:
             if dir_path is None:
                 dir_path = os.path.join(self.root_dir, dir_name)
+            elif not os.path.isabs(dir_path):
+                dir_path = os.path.join(self.root_dir, dir_path)
 
             if not os.path.exists(dir_path):
                 os.makedirs(dir_path)
@@ -313,6 +320,8 @@ class LSFS:
         """Write to file with proper lock management."""
         if file_path is None:
             file_path = os.path.join(self.root_dir, file_name)
+        elif not os.path.isabs(file_path):
+            file_path = os.path.join(self.root_dir, file_path)
 
         lock = self.get_file_lock(file_path)
         try:


### PR DESCRIPTION
## fix: resolve storage file creation writing to wrong directory

### Problem

When an agent requests file creation through the AIOS storage system (e.g., `create_file` with `file_path="hello_world.txt"`), the file is created in the repository root (`AIOS/`) instead of the configured storage root (`AIOS/root/`).

### Root Cause

Two issues in `aios/storage/filesystem/lsfs.py`:

1. **Positional argument mismatch in `address_request()`**: The `create_file` branch called `self.sto_create_file(file_path, collection_name)` positionally, but the method signature is `sto_create_file(self, file_name, file_path, collection_name=None)`. This caused `file_path` to be interpreted as `file_name` and the agent name to be interpreted as `file_path`.

2. **Relative paths not resolved against `root_dir`**: Even after fixing the argument order, `sto_create_file`, `sto_create_directory`, and `sto_write` only prepend `self.root_dir` when `file_path is None`. When an agent provides a relative path like `"hello_world.txt"`, it was used as-is — creating the file relative to the process working directory instead of under `root/`.

### Changes

**File:** `aios/storage/filesystem/lsfs.py`

- **`address_request()`** — switched the `create_file` branch from positional args to keyword args (`file_name=`, `file_path=`, `collection_name=`), consistent with all other operation branches. Also extracts `file_name` from params.
- **`sto_create_file()`** — added `elif not os.path.isabs(file_path)` to join relative paths with `self.root_dir`.
- **`sto_create_directory()`** — same relative path fix.
- **`sto_write()`** — same relative path fix.

### Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `create_file(file_path="hello.txt")` | Created at `AIOS/hello.txt` | Created at `AIOS/root/hello.txt` |
| `create_file(file_path="/tmp/hello.txt")` | Created at `/tmp/hello.txt` | Created at `/tmp/hello.txt` (absolute paths unchanged) |
| `write(file_path="notes.txt", ...)` | Wrote to `AIOS/notes.txt` | Wrote to `AIOS/root/notes.txt` |

### Documentation

No documentation changes required. This is a bugfix to internal storage path resolution logic with no API surface changes.

### Testing

Verified manually by running the AIOS kernel and requesting file creation — files now land in `AIOS/root/` as expected.
