### PR TITLE
fix(dependencies): fixed failed builds because of dependencies

### DIFF
--- a/.github/workflows/test-ollama.yml
+++ b/.github/workflows/test-ollama.yml
@@ -38,6 +38,9 @@ jobs:
           source .venv/bin/activate
           uv pip install -r requirements.txt
       
+      - name: Create config from example
+        run: cp aios/config/config.yaml.example aios/config/config.yaml
+
       - name: Install Ollama
         run: | 
           curl -fsSL https://ollama.com/install.sh | sh

--- a/.github/workflows/test-qdrant.yml
+++ b/.github/workflows/test-qdrant.yml
@@ -45,6 +45,9 @@ jobs:
           source .venv/bin/activate
           uv pip install -r requirements.txt
       
+      - name: Create config from example
+        run: cp aios/config/config.yaml.example aios/config/config.yaml
+
       - name: Run Qdrant integration tests
         run: |
           source .venv/bin/activate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 litellm
-pydantic==2.7.0
+pydantic>=2.7.0
 click==8.1.7
 fastapi
 uvicorn
@@ -27,4 +27,5 @@ fastembed
 
 # Memory provider integrations (optional)
 mem0ai>=1.0.11
-zep-cloud
+# Pinned to 2.0.0 — later versions have API incompatibilities with Zep free tier
+zep-cloud==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,13 @@ typing-extensions
 qdrant-client
 fastembed
 
+# Pin opentelemetry packages — chromadb pulls in old versions
+# whose generated protobuf code is incompatible with protobuf v5+
+opentelemetry-api>=1.25.0
+opentelemetry-sdk>=1.25.0
+opentelemetry-exporter-otlp-proto-grpc>=1.25.0
+opentelemetry-proto>=1.25.0
+
 # Memory provider integrations (optional)
 mem0ai>=1.0.11
 # Pinned to 2.0.0 — later versions have API incompatibilities with Zep free tier


### PR DESCRIPTION
# Fix CI dependency resolution and test configuration

## Problem

CI builds were failing with three cascading issues:

1. **pydantic version conflict** — `pydantic==2.7.0` was pinned exactly, but `mem0ai>=1.0.11` requires `pydantic>=2.7.3`, making the dependency tree unsatisfiable.
2. **protobuf/opentelemetry incompatibility** — ChromaDB pulled in old `opentelemetry-proto==1.11.1` whose generated protobuf stubs are incompatible with `protobuf` v5+, causing `TypeError: Descriptors cannot be created directly` at import time.
3. **Missing `config.yaml` in CI** — `config.yaml` is gitignored, so the `ConfigManager` singleton raised `FileNotFoundError` when tests tried to import modules that depend on it.

## Changes

### `requirements.txt`
- Relaxed `pydantic==2.7.0` → `pydantic>=2.7.0` to allow the resolver to satisfy both our floor and `mem0ai`'s constraint.
- Pinned `zep-cloud==2.0.0` with a comment — later versions have API incompatibilities with the Zep free tier.
- Added floor pins for `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-grpc`, and `opentelemetry-proto` (all `>=1.25.0`) to ensure protobuf v5+ compatibility.

### `.github/workflows/test-qdrant.yml`
- Added a `Create config from example` step that copies `config.yaml.example` → `config.yaml` before tests run.

### `.github/workflows/test-ollama.yml`
- Same `Create config from example` step added for consistency.