### PR TITLE
fix: mem0 semantic retrieval returned 0 results, plus robust MCP server path

### DIFF
--- a/aios/config/config.yaml.example
+++ b/aios/config/config.yaml.example
@@ -45,7 +45,7 @@ llms:
     #   backend: "huggingface"
     #   max_gpu_memory: {0: "48GB"}  # GPU memory allocation
     #   eval_device: "cuda:0"  # Device for model evaluation
-    
+
     # vLLM Models
     # To use vllm as backend, you need to install vllm and run the vllm server https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
     # An example command to run the vllm server is:
@@ -103,13 +103,17 @@ storage:
   root_dir: "root"
   use_vector_db: true
 
+tool:
+  # Optional. If omitted, AIOS defaults to aios/tool/mcp_server.py.
+  mcp_server_script_path: "aios/tool/mcp_server.py"
+
 scheduler:
   log_mode: "console" # choose from [console, file]
 
 agent_factory:
   log_mode: "console" # choose from [console, file]
-  max_workers: 64  
-  
+  max_workers: 64
+
 server:
   host: "localhost"
   port: 8000

--- a/aios/config/config_manager.py
+++ b/aios/config/config_manager.py
@@ -1,39 +1,39 @@
 import os
 import yaml
-from typing import Any, Optional
+from typing import Optional
 
 class ConfigManager:
     """
     A singleton class that manages configuration settings for the AIOS system.
-    
+
     Class Variables:
         _instance (ConfigManager): Singleton instance of the class
         config_path (str): Path to the configuration file
         config (dict): Dictionary containing all configuration settings
-    
+
     Example:
         # Get the global config instance
         config_manager = ConfigManager()
-        
+
         # Update API key
         config_manager.update_api_key("openai", "sk-...")
-        
+
         # Get LLM configuration
         llm_config = config_manager.get_llms_config()
     """
     _instance = None
-    
+
     def __new__(cls):
         """
         Ensures only one instance of ConfigManager is created (Singleton pattern).
-        
+
         Returns:
             ConfigManager: The singleton instance
         """
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
-    
+
     def __init__(self):
         """
         Initializes the ConfigManager if not already initialized.
@@ -46,35 +46,35 @@ class ConfigManager:
                 'config.yaml'
             )
             self.load_config()
-    
+
     def load_config(self):
         """
         Loads configuration from the YAML file.
-        
+
         Raises:
             FileNotFoundError: If the config file doesn't exist
         """
         if not os.path.exists(self.config_path):
             raise FileNotFoundError(f"Config file not found at {self.config_path}")
-            
+
         with open(self.config_path, 'r') as f:
             self.config = yaml.safe_load(f)
-    
+
     def save_config(self):
         """
         Saves the current configuration to the YAML file.
         """
         with open(self.config_path, 'w') as f:
             yaml.safe_dump(self.config, f)
-    
+
     def update_api_key(self, provider: str, api_key: str):
         """
         Updates the API key for a specified provider in the configuration.
-        
+
         Args:
             provider (str): The name of the API provider (e.g., "openai", "anthropic")
             api_key (str): The API key to be stored
-            
+
         Example:
             config_manager.update_api_key("openai", "sk-...")
         """
@@ -82,15 +82,15 @@ class ConfigManager:
             self.config["api_keys"] = {}
         self.config["api_keys"][provider] = api_key
         self.save_config()
-    
+
     def update_llm_config(self, model: str, backend: str):
         """
         Updates the default LLM configuration.
-        
+
         Args:
             model (str): The model identifier
             backend (str): The backend service to use
-            
+
         Example:
             config_manager.update_llm_config("gpt-4", "openai")
         """
@@ -99,23 +99,23 @@ class ConfigManager:
         self.config["llm"]["default_model"] = model
         self.config["llm"]["backend"] = backend
         self.save_config()
-    
+
     def refresh(self):
         """
         Reloads the configuration from the file to get the latest changes.
         """
         self.load_config()
-    
+
     def get_api_key(self, provider: str) -> Optional[str]:
         """
         Retrieves the API key for a specified provider, checking both config file and environment variables.
-        
+
         Args:
             provider (str): The name of the API provider (e.g., "openai", "anthropic")
-            
+
         Returns:
             Optional[str]: The API key if found, None otherwise
-            
+
         Example:
             api_key = config_manager.get_api_key("openai")
             if api_key:
@@ -123,21 +123,21 @@ class ConfigManager:
                 pass
         """
         print(f"\n=== ConfigManager: Getting API key for {provider} ===")
-        
+
         # First try to get from config file
         api_key = None
         if provider == "huggingface":
             api_key = self.config.get("api_keys", {}).get("huggingface", {})
         else:
             api_key = self.config.get("api_keys", {}).get(provider)
-        
+
         print(f"- Checking config.yaml: {'Found' if api_key else 'Not found'}")
-        
+
         # If not found in config, try environment variables
         if not api_key:
             env_var_map = {
                 "openai": "OPENAI_API_KEY",
-                "gemini": "GEMINI_API_KEY", 
+                "gemini": "GEMINI_API_KEY",
                 "groq": "GROQ_API_KEY",
                 "anthropic": "ANTHROPIC_API_KEY",
                 "huggingface": "HF_AUTH_TOKEN"
@@ -146,51 +146,51 @@ class ConfigManager:
                 env_var = env_var_map[provider]
                 api_key = os.environ.get(env_var)
                 print(f"- Checking environment variable {env_var}: {'Found' if api_key else 'Not found'}")
-            
+
         return api_key
-    
+
     def get_llms_config(self) -> dict:
         """
         Retrieves the LLM configuration settings.
-        
+
         Returns:
             dict: Dictionary containing LLM configurations
-            
+
         Example:
             llm_config = config_manager.get_llms_config()
             default_model = llm_config.get("default_model")
         """
         return self.config.get('llms', {})
-    
+
     def get_router_config(self) -> dict:
         """
         Retrieves the router configuration settings.
-        
+
         Returns:
             dict: Dictionary containing router configurations
         """
         return self.config.get("llms", {}).get("router", {})
-    
+
     def get_storage_config(self) -> dict:
         """
         Retrieves the storage configuration settings.
-        
+
         Returns:
             dict: Dictionary containing storage configurations
-            
+
         Example:
             storage_config = config_manager.get_storage_config()
             storage_path = storage_config.get("path")
         """
         return self.config.get("storage", {})
-    
+
     def get_memory_config(self) -> dict:
         """
         Retrieves the memory configuration settings.
-        
+
         Returns:
             dict: Dictionary containing memory configurations
-            
+
         Example:
             memory_config = config_manager.get_memory_config()
             memory_type = memory_config.get("type")
@@ -200,65 +200,78 @@ class ConfigManager:
     def get_tool_config(self) -> dict:
         """
         Retrieves the tool configuration settings.
-        
+
         Returns:
             dict: Dictionary containing tool configurations
-            
+
         Example:
             tool_config = config_manager.get_tool_config()
             enabled_tools = tool_config.get("enabled")
         """
         return self.config.get("tool", {})
-    
+
     def get_mcp_server_script_path(self) -> str:
         """
         Retrieves the path to the MCP server script.
         """
-        return os.path.join(os.getcwd(), self.config.get("tool", {}).get("mcp_server_script_path"))
-    
+        configured_path = self.config.get("tool", {}).get("mcp_server_script_path")
+
+        # Default to the in-repo MCP server script when no explicit config is provided.
+        if not configured_path:
+            return os.path.join(
+                os.path.dirname(os.path.dirname(__file__)),
+                "tool",
+                "mcp_server.py",
+            )
+
+        if os.path.isabs(configured_path):
+            return configured_path
+
+        return os.path.join(os.getcwd(), configured_path)
+
     def get_scheduler_config(self) -> dict:
         """
         Retrieves the scheduler configuration settings.
-        
+
         Returns:
             dict: Dictionary containing scheduler configurations
-            
+
         Example:
             scheduler_config = config_manager.get_scheduler_config()
             max_tasks = scheduler_config.get("max_concurrent_tasks")
         """
         return self.config.get("scheduler", {})
-    
+
     def get_agent_factory_config(self) -> dict:
         """
         Retrieves the agent factory configuration settings.
-        
+
         Returns:
             dict: Dictionary containing agent factory configurations
-            
+
         Example:
             factory_config = config_manager.get_agent_factory_config()
             agent_types = factory_config.get("available_agents")
         """
         return self.config.get("agent_factory", {})
-    
+
     def get_server_config(self) -> dict:
         """
         Retrieves the server configuration settings.
-        
+
         Returns:
             dict: Dictionary containing server configurations
-            
+
         Example:
             server_config = config_manager.get_server_config()
             host = server_config.get("host")
             port = server_config.get("port")
         """
         return self.config.get("server", {})
-    
+
     # def get_kernel_config(self) -> dict:
     #     """Get kernel configuration"""
     #     return self.config.get("kernel", {})
 
 # Global config instance
-config = ConfigManager() 
+config = ConfigManager()

--- a/aios/memory/manager.py
+++ b/aios/memory/manager.py
@@ -183,6 +183,15 @@ class MemoryManager:
         
         if operation_type == "add_memory":
             memory_note = self._analyze_query_to_memory(query)
+            # Default owner_agent to the requesting agent so retrieval's
+            # sharing filter (which matches owner_agent against the agent
+            # asking) can find the agent's own memories. Explicit values
+            # (e.g. from ConversationExtractor) are preserved.
+            if memory_note.metadata is None:
+                memory_note.metadata = {}
+            memory_note.metadata.setdefault(
+                "owner_agent", memory_syscall.agent_name
+            )
             # Track user_id for cross-agent discovery.
             uid = (memory_note.metadata or {}).get("user_id")
             if uid and uid != query.params.get("agent_name", ""):

--- a/aios/memory/providers/mem0.py
+++ b/aios/memory/providers/mem0.py
@@ -282,12 +282,18 @@ class Mem0Provider(MemoryProvider):
             # Build add parameters
             add_kwargs = {
                 "user_id": user_id,
-                "metadata": metadata
+                "metadata": metadata,
+                # Store the MemoryNote verbatim. With the default infer=True,
+                # Mem0 runs LLM fact-extraction over the content and, with
+                # small/local models, often returns {"results": []} — silently
+                # storing nothing. We already pass fully-formed notes, so skip
+                # inference and persist the text as-is.
+                "infer": False,
             }
-            
+
             if agent_id:
                 add_kwargs["agent_id"] = agent_id
-            
+
             # Add memory to Mem0
             result = self.client.add(memory_note.content, **add_kwargs)
             

--- a/aios/tool/manager.py
+++ b/aios/tool/manager.py
@@ -1,7 +1,6 @@
-import importlib
 import subprocess
 import os # Added for path manipulation
-import signal # Added to send signals to subprocess
+import sys
 
 # from cerebrum.llm.communication import Response
 
@@ -23,21 +22,21 @@ class ToolManager:
         self.tool_conflict_map_lock = Lock()
         self.mcp_server_process = None # To store the mcp_server subprocess
         self._start_mcp_server() # Start mcp_server on initialization
-        
+
     def _start_mcp_server(self):
         """Starts the mcp_server.py script as a background subprocess."""
         if self.mcp_server_process is None or self.mcp_server_process.poll() is not None:
             try:
                 # Assuming mcp_server.py is in the same directory as manager.py
                 mcp_server_script_path = config.get_mcp_server_script_path()
-                if not os.path.exists(mcp_server_script_path):
+                if not mcp_server_script_path or not os.path.exists(mcp_server_script_path):
                     print(f"Error: mcp_server.py not found at {mcp_server_script_path}")
                     return
 
                 # Start the server
                 # We use Popen for non-blocking execution and to manage the process
                 self.mcp_server_process = subprocess.Popen(
-                    ["python", mcp_server_script_path],
+                    [sys.executable, mcp_server_script_path],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True
@@ -71,18 +70,18 @@ class ToolManager:
                 self.mcp_server_process = None
         else:
             print("MCP Server is not running or already stopped.")
-            
+
     def cleanup(self):
         """Cleanup resources, including stopping the mcp_server."""
         print("Cleaning up ToolManager...")
         self._stop_mcp_server()
-        
+
     def address_request(self, syscall) -> None:
         tool_calls = syscall.query.tool_calls
 
-        if tool_calls == None or len(tool_calls) == 0:
+        if tool_calls is None or len(tool_calls) == 0:
             return ToolResponse(
-                response_message=f"There is no tool to call",
+                response_message="There is no tool to call",
                 finished=False
             )
         # breakpoint()
@@ -102,12 +101,12 @@ class ToolManager:
                         tool_result = tool.run(params=tool_params)
 
                         self.tool_conflict_map.pop(tool_org_and_name)
-                        
+
                         return ToolResponse(
                             response_message=tool_result,
                             finished=True
                         )
-                    
+
         except Exception as e:
             return ToolResponse(
                 response_message=f"Tool calling error: {e}",

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,8 @@ opentelemetry-proto>=1.25.0
 
 # Memory provider integrations (optional)
 mem0ai>=1.0.11
+# Required by mem0's Ollama embedder/LLM backend; mem0 imports it lazily
+# and otherwise prompts for an interactive install (fails non-interactively)
+ollama
 # Pinned to 2.0.0 — later versions have API incompatibilities with Zep free tier
 zep-cloud==2.0.0


### PR DESCRIPTION
## Summary

Two independent kernel fixes, both exercised locally against a real mem0 + Ollama setup.

### 1. mem0 semantic retrieval returned 0 results (`e79b9c6`)

`add`/`get` reported success but semantic retrieval returned nothing. Two root causes:

- **Silent no-op on add.** mem0 2.0.6 defaults to `infer=True`, running LLM fact-extraction over the content. With small/local models (e.g. qwen2.5:7b) this often yields `{"results": []}` and stores nothing, while `add_memory` still reports success via a fallback id. We already pass fully-formed `MemoryNote`s, so we now pass `infer=False` to persist them verbatim.
- **Sharing-filter asymmetry.** Retrieval injects `agent_name` and the cross-agent sharing filter matches `owner_agent` against it, but `add` never set `owner_agent` — so an agent could not find its own memories. We now `setdefault` `owner_agent` to the requesting agent on add (explicit values from `ConversationExtractor` are preserved). Applies to all providers via the shared `_apply_sharing_filter`.
- Adds the `ollama` package to requirements — mem0's Ollama backend imports it lazily and otherwise prompts for an interactive install (fails non-interactively).

Per the memory provider test suite (`test_mem0_provider.py`): 8/10 → 12/12.

### 2. Robust MCP server script path resolution (`6b63d85`)

- `get_mcp_server_script_path()` now defaults to the in-repo `aios/tool/mcp_server.py` when unset, and handles absolute paths (previously it crashed on a `None` config and always prefixed `os.getcwd()`).
- Launch the MCP server via `sys.executable` instead of a hardcoded `"python"`.
- Guard against a missing script path before `os.path.exists`.
- Document `tool.mcp_server_script_path` in `config.yaml.example`.

## Testing

- `test_mem0_provider.py`: 8/10 → 12/12 for the memory fix.
- pre-commit (ruff, trailing-whitespace, end-of-file, check-yaml) clean on all touched files.